### PR TITLE
feat: make path for cleveldb, rocksdb

### DIFF
--- a/cleveldb/db.go
+++ b/cleveldb/db.go
@@ -2,6 +2,7 @@ package cleveldb
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/jmhodges/levigo"
@@ -21,6 +22,11 @@ var _ tmdb.DB = (*CLevelDB)(nil)
 
 // New creates a new CLevelDB.
 func NewDB(name string, dir string) (*CLevelDB, error) {
+	err := os.MkdirAll(dir, 0755)
+	if err != nil {
+		return nil, err
+	}
+
 	dbPath := filepath.Join(dir, name+".db")
 
 	opts := levigo.NewOptions()

--- a/rocksdb/db.go
+++ b/rocksdb/db.go
@@ -2,6 +2,7 @@ package rocksdb
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 
@@ -20,6 +21,11 @@ type RocksDB struct {
 var _ tmdb.DB = (*RocksDB)(nil)
 
 func NewDB(name string, dir string) (*RocksDB, error) {
+	err := os.MkdirAll(dir, 0755)
+	if err != nil {
+		return nil, err
+	}
+
 	// default rocksdb option, good enough for most cases, including heavy workloads.
 	// 1GB table cache, 512MB write buffer(may use 50% more on heavy workloads).
 	// compression: snappy as default, need to -lsnappy to enable.


### PR DESCRIPTION
* `goleveldb` make all path when opening file.
  * https://github.com/syndtr/goleveldb/blob/64b5b1c739545ed311fb9d9924d19d188fabdc83/leveldb/storage/file_storage.go#L95
* `cleveldb` and `rocksdb` don't have this feature.
* For consistent behavior between db backends, I'd like to add `MkdirAll()` for  `cleveldb` and `rocksdb`.

Please note that I'll revert part of https://github.com/line/lbm/pull/1249 if this PR is approved & merged.