### PR TITLE
chore: package `prefixdb`

### DIFF
--- a/goleveldb/iterator.go
+++ b/goleveldb/iterator.go
@@ -99,7 +99,7 @@ func (itr *goLevelDBIterator) Key() []byte {
 	// Key returns a copy of the current key.
 	// See https://github.com/syndtr/goleveldb/blob/52c212e6c196a1404ea59592d3f1c227c9f034b2/leveldb/iterator/iter.go#L88
 	itr.assertIsValid()
-	return cp(itr.source.Key())
+	return tmdb.Cp(itr.source.Key())
 }
 
 // Value implements Iterator.
@@ -107,13 +107,7 @@ func (itr *goLevelDBIterator) Value() []byte {
 	// Value returns a copy of the current value.
 	// See https://github.com/syndtr/goleveldb/blob/52c212e6c196a1404ea59592d3f1c227c9f034b2/leveldb/iterator/iter.go#L88
 	itr.assertIsValid()
-	return cp(itr.source.Value())
-}
-
-func cp(bz []byte) (ret []byte) {
-	ret = make([]byte, len(bz))
-	copy(ret, bz)
-	return ret
+	return tmdb.Cp(itr.source.Value())
 }
 
 // Next implements Iterator.

--- a/metadb/backend_test.go
+++ b/metadb/backend_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/line/tm-db/v2/goleveldb"
 	"github.com/line/tm-db/v2/internal/dbtest"
 	"github.com/line/tm-db/v2/memdb"
+	"github.com/line/tm-db/v2/prefixdb"
 	"github.com/line/tm-db/v2/rocksdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,7 +28,7 @@ func init() {
 		mdb.Set([]byte("test"), []byte{0})
 		mdb.Set([]byte("u"), []byte{21})
 		mdb.Set([]byte("z"), []byte{26})
-		return tmdb.NewPrefixDB(mdb, []byte("test/")), nil
+		return prefixdb.NewDB(mdb, []byte("test/")), nil
 	}, false)
 }
 

--- a/metadb/util_test.go
+++ b/metadb/util_test.go
@@ -10,6 +10,7 @@ import (
 
 	tmdb "github.com/line/tm-db/v2"
 	"github.com/line/tm-db/v2/internal/dbtest"
+	"github.com/line/tm-db/v2/prefixdb"
 )
 
 // Empty iterator for empty db.
@@ -18,7 +19,7 @@ func TestPrefixIteratorNoMatchNil(t *testing.T) {
 		t.Run(fmt.Sprintf("Prefix w/ backend %s", backend), func(t *testing.T) {
 			db, dir := newTempDB(t, backend)
 			defer os.RemoveAll(dir)
-			itr, err := tmdb.IteratePrefix(db, []byte("2"))
+			itr, err := prefixdb.IteratePrefix(db, []byte("2"))
 			require.NoError(t, err)
 
 			dbtest.Invalid(t, itr)
@@ -37,7 +38,7 @@ func TestPrefixIteratorNoMatch1(t *testing.T) {
 		t.Run(fmt.Sprintf("Prefix w/ backend %s", backend), func(t *testing.T) {
 			db, dir := newTempDB(t, backend)
 			defer os.RemoveAll(dir)
-			itr, err := tmdb.IteratePrefix(db, []byte("2"))
+			itr, err := prefixdb.IteratePrefix(db, []byte("2"))
 			require.NoError(t, err)
 			err = db.SetSync([]byte("1"), []byte("value_1"))
 			require.NoError(t, err)
@@ -55,7 +56,7 @@ func TestPrefixIteratorNoMatch2(t *testing.T) {
 			defer os.RemoveAll(dir)
 			err := db.SetSync([]byte("3"), []byte("value_3"))
 			require.NoError(t, err)
-			itr, err := tmdb.IteratePrefix(db, []byte("4"))
+			itr, err := prefixdb.IteratePrefix(db, []byte("4"))
 			require.NoError(t, err)
 
 			dbtest.Invalid(t, itr)
@@ -71,7 +72,7 @@ func TestPrefixIteratorMatch1(t *testing.T) {
 			defer os.RemoveAll(dir)
 			err := db.SetSync([]byte("2"), []byte("value_2"))
 			require.NoError(t, err)
-			itr, err := tmdb.IteratePrefix(db, []byte("2"))
+			itr, err := prefixdb.IteratePrefix(db, []byte("2"))
 			require.NoError(t, err)
 
 			dbtest.Valid(t, itr, true)
@@ -106,7 +107,7 @@ func TestPrefixIteratorMatches1N(t *testing.T) {
 			require.NoError(t, err)
 			err = db.SetSync([]byte("abcdefg"), []byte("value_3"))
 			require.NoError(t, err)
-			itr, err := tmdb.IteratePrefix(db, []byte("a/"))
+			itr, err := prefixdb.IteratePrefix(db, []byte("a/"))
 			require.NoError(t, err)
 
 			dbtest.Valid(t, itr, true)

--- a/prefixdb/batch.go
+++ b/prefixdb/batch.go
@@ -1,13 +1,17 @@
-package db
+package prefixdb
+
+import (
+	tmdb "github.com/line/tm-db/v2"
+)
 
 type prefixDBBatch struct {
 	prefix []byte
-	source Batch
+	source tmdb.Batch
 }
 
-var _ Batch = (*prefixDBBatch)(nil)
+var _ tmdb.Batch = (*prefixDBBatch)(nil)
 
-func newPrefixBatch(prefix []byte, source Batch) prefixDBBatch {
+func newPrefixBatch(prefix []byte, source tmdb.Batch) prefixDBBatch {
 	return prefixDBBatch{
 		prefix: prefix,
 		source: source,
@@ -17,21 +21,21 @@ func newPrefixBatch(prefix []byte, source Batch) prefixDBBatch {
 // Set implements Batch.
 func (pb prefixDBBatch) Set(key, value []byte) error {
 	if len(key) == 0 {
-		return ErrKeyEmpty
+		return tmdb.ErrKeyEmpty
 	}
 	if value == nil {
-		return ErrValueNil
+		return tmdb.ErrValueNil
 	}
-	pkey := concat(pb.prefix, key)
+	pkey := tmdb.Concat(pb.prefix, key)
 	return pb.source.Set(pkey, value)
 }
 
 // Delete implements Batch.
 func (pb prefixDBBatch) Delete(key []byte) error {
 	if len(key) == 0 {
-		return ErrKeyEmpty
+		return tmdb.ErrKeyEmpty
 	}
-	pkey := concat(pb.prefix, key)
+	pkey := tmdb.Concat(pb.prefix, key)
 	return pb.source.Delete(pkey)
 }
 

--- a/prefixdb/db_test.go
+++ b/prefixdb/db_test.go
@@ -1,4 +1,4 @@
-package db_test
+package prefixdb_test
 
 import (
 	"testing"
@@ -6,6 +6,7 @@ import (
 	tmdb "github.com/line/tm-db/v2"
 	"github.com/line/tm-db/v2/internal/dbtest"
 	"github.com/line/tm-db/v2/memdb"
+	"github.com/line/tm-db/v2/prefixdb"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,7 +26,7 @@ func mockDBWithStuff(t *testing.T) tmdb.DB {
 
 func TestPrefixDBSimple(t *testing.T) {
 	db := mockDBWithStuff(t)
-	pdb := tmdb.NewPrefixDB(db, []byte("key"))
+	pdb := prefixdb.NewDB(db, []byte("key"))
 
 	dbtest.Value(t, pdb, []byte("key"), nil)
 	dbtest.Value(t, pdb, []byte("key1"), nil)
@@ -42,7 +43,7 @@ func TestPrefixDBSimple(t *testing.T) {
 
 func TestPrefixDBIterator1(t *testing.T) {
 	db := mockDBWithStuff(t)
-	pdb := tmdb.NewPrefixDB(db, []byte("key"))
+	pdb := prefixdb.NewDB(db, []byte("key"))
 
 	itr, err := pdb.Iterator(nil, nil)
 	require.NoError(t, err)
@@ -59,7 +60,7 @@ func TestPrefixDBIterator1(t *testing.T) {
 
 func TestPrefixDBReverseIterator1(t *testing.T) {
 	db := mockDBWithStuff(t)
-	pdb := tmdb.NewPrefixDB(db, []byte("key"))
+	pdb := prefixdb.NewDB(db, []byte("key"))
 
 	itr, err := pdb.ReverseIterator(nil, nil)
 	require.NoError(t, err)
@@ -76,7 +77,7 @@ func TestPrefixDBReverseIterator1(t *testing.T) {
 
 func TestPrefixDBReverseIterator5(t *testing.T) {
 	db := mockDBWithStuff(t)
-	pdb := tmdb.NewPrefixDB(db, []byte("key"))
+	pdb := prefixdb.NewDB(db, []byte("key"))
 
 	itr, err := pdb.ReverseIterator([]byte("1"), nil)
 	require.NoError(t, err)
@@ -93,7 +94,7 @@ func TestPrefixDBReverseIterator5(t *testing.T) {
 
 func TestPrefixDBReverseIterator6(t *testing.T) {
 	db := mockDBWithStuff(t)
-	pdb := tmdb.NewPrefixDB(db, []byte("key"))
+	pdb := prefixdb.NewDB(db, []byte("key"))
 
 	itr, err := pdb.ReverseIterator([]byte("2"), nil)
 	require.NoError(t, err)
@@ -108,7 +109,7 @@ func TestPrefixDBReverseIterator6(t *testing.T) {
 
 func TestPrefixDBReverseIterator7(t *testing.T) {
 	db := mockDBWithStuff(t)
-	pdb := tmdb.NewPrefixDB(db, []byte("key"))
+	pdb := prefixdb.NewDB(db, []byte("key"))
 
 	itr, err := pdb.ReverseIterator(nil, []byte("2"))
 	require.NoError(t, err)

--- a/prefixdb/iterator.go
+++ b/prefixdb/iterator.go
@@ -1,20 +1,22 @@
-package db
+package prefixdb
 
 import (
 	"bytes"
 	"fmt"
+
+	tmdb "github.com/line/tm-db/v2"
 )
 
 // IteratePrefix is a convenience function for iterating over a key domain
 // restricted by prefix.
-func IteratePrefix(db DB, prefix []byte) (Iterator, error) {
+func IteratePrefix(db tmdb.DB, prefix []byte) (tmdb.Iterator, error) {
 	var start, end []byte
 	if len(prefix) == 0 {
 		start = nil
 		end = nil
 	} else {
-		start = cp(prefix)
-		end = cpIncr(prefix)
+		start = tmdb.Cp(prefix)
+		end = tmdb.CpIncr(prefix)
 	}
 	itr, err := db.Iterator(start, end)
 	if err != nil {
@@ -28,14 +30,14 @@ type prefixDBIterator struct {
 	prefix []byte
 	start  []byte
 	end    []byte
-	source Iterator
+	source tmdb.Iterator
 	valid  bool
 	err    error
 }
 
-var _ Iterator = (*prefixDBIterator)(nil)
+var _ tmdb.Iterator = (*prefixDBIterator)(nil)
 
-func newPrefixIterator(prefix, start, end []byte, source Iterator) (*prefixDBIterator, error) {
+func newPrefixIterator(prefix, start, end []byte, source tmdb.Iterator) (*prefixDBIterator, error) {
 	pitrInvalid := &prefixDBIterator{
 		prefix: prefix,
 		start:  start,

--- a/util.go
+++ b/util.go
@@ -5,20 +5,20 @@ import (
 	"os"
 )
 
-func cp(bz []byte) (ret []byte) {
+func Cp(bz []byte) (ret []byte) {
 	ret = make([]byte, len(bz))
 	copy(ret, bz)
 	return ret
 }
 
-func concat(bz1 []byte, bz2 []byte) (ret []byte) {
+func Concat(bz1 []byte, bz2 []byte) (ret []byte) {
 	bz1len := len(bz1)
 	if bz1len == 0 {
-		return cp(bz2)
+		return Cp(bz2)
 	}
 	bz2len := len(bz2)
 	if bz2len == 0 {
-		return cp(bz1)
+		return Cp(bz1)
 	}
 
 	ret = make([]byte, bz1len+bz2len)
@@ -31,11 +31,11 @@ func concat(bz1 []byte, bz2 []byte) (ret []byte) {
 // except incremented by one.
 // Returns nil on overflow (e.g. if bz bytes are all 0xFF)
 // CONTRACT: len(bz) > 0
-func cpIncr(bz []byte) (ret []byte) {
+func CpIncr(bz []byte) (ret []byte) {
 	if len(bz) == 0 {
 		panic("cpIncr expects non-zero bz length")
 	}
-	ret = cp(bz)
+	ret = Cp(bz)
 	for i := len(bz) - 1; i >= 0; i-- {
 		if ret[i] < byte(0xFF) {
 			ret[i]++

--- a/util_test.go
+++ b/util_test.go
@@ -10,7 +10,7 @@ func BenchmarkConcat(b *testing.B) {
 	bz1 := []byte("prefix")
 	bz2 := []byte("key")
 	for i := 0; i < b.N; i++ {
-		_ = concat(bz1, bz2)
+		_ = Concat(bz1, bz2)
 	}
 }
 
@@ -18,7 +18,7 @@ func BenchmarkPrefixed(b *testing.B) {
 	bz1 := []byte("prefix")
 	bz2 := []byte("key")
 	for i := 0; i < b.N; i++ {
-		_ = append(cp(bz1), bz2...)
+		_ = append(Cp(bz1), bz2...)
 	}
 }
 
@@ -32,8 +32,8 @@ func BenchmarkBytesJoin(b *testing.B) {
 func TestConcat(t *testing.T) {
 	prefix := []byte("prefix")
 	key := []byte("key")
-	require.Equal(t, bytes.Join([][]byte{prefix, key}, nil), concat(prefix, key))
-	require.Equal(t, prefix, concat(prefix, nil))
-	require.Equal(t, key, concat(nil, key))
-	require.Equal(t, []byte{}, concat(nil, nil))
+	require.Equal(t, bytes.Join([][]byte{prefix, key}, nil), Concat(prefix, key))
+	require.Equal(t, prefix, Concat(prefix, nil))
+	require.Equal(t, key, Concat(nil, key))
+	require.Equal(t, []byte{}, Concat(nil, nil))
 }


### PR DESCRIPTION
After #2, there is only one db, `prefixdb`, is left in the root directory. I'd like to package `prefixdb` as well to follow #2 up.