### PR TITLE
chore: pointer receiver for cLevelDBIterator

### DIFF
--- a/cleveldb/iterator.go
+++ b/cleveldb/iterator.go
@@ -49,12 +49,12 @@ func newCLevelDBIterator(source *levigo.Iterator, start, end []byte, isReverse b
 }
 
 // Domain implements Iterator.
-func (itr cLevelDBIterator) Domain() ([]byte, []byte) {
+func (itr *cLevelDBIterator) Domain() ([]byte, []byte) {
 	return itr.start, itr.end
 }
 
 // Valid implements Iterator.
-func (itr cLevelDBIterator) Valid() bool {
+func (itr *cLevelDBIterator) Valid() bool {
 
 	// Once invalid, forever invalid.
 	if itr.isInvalid {
@@ -94,19 +94,19 @@ func (itr cLevelDBIterator) Valid() bool {
 }
 
 // Key implements Iterator.
-func (itr cLevelDBIterator) Key() []byte {
+func (itr *cLevelDBIterator) Key() []byte {
 	itr.assertIsValid()
 	return itr.source.Key()
 }
 
 // Value implements Iterator.
-func (itr cLevelDBIterator) Value() []byte {
+func (itr *cLevelDBIterator) Value() []byte {
 	itr.assertIsValid()
 	return itr.source.Value()
 }
 
 // Next implements Iterator.
-func (itr cLevelDBIterator) Next() {
+func (itr *cLevelDBIterator) Next() {
 	itr.assertIsValid()
 	if itr.isReverse {
 		itr.source.Prev()
@@ -116,17 +116,17 @@ func (itr cLevelDBIterator) Next() {
 }
 
 // Error implements Iterator.
-func (itr cLevelDBIterator) Error() error {
+func (itr *cLevelDBIterator) Error() error {
 	return itr.source.GetError()
 }
 
 // Close implements Iterator.
-func (itr cLevelDBIterator) Close() error {
+func (itr *cLevelDBIterator) Close() error {
 	itr.source.Close()
 	return nil
 }
 
-func (itr cLevelDBIterator) assertIsValid() {
+func (itr *cLevelDBIterator) assertIsValid() {
 	if !itr.Valid() {
 		panic("iterator is invalid")
 	}


### PR DESCRIPTION
* All other db iterator uses `pointer receiver`, except `cleveldb` iterator. In terms of consistency, it's better that `cleveldb` iterator also uses `pointer receiver`.
* `pointer receiver` is more performant than `value receiver` in this case.

### Benchmark w/ `pointer receiver`
```
BenchmarkCLevelDBRangeScans1M-12         	     127	   9198671 ns/op
BenchmarkCLevelDBRangeScans10M-12        	     120	  11307824 ns/op
BenchmarkCLevelDBRandomReadsWrites-12    	  181062	      7396 ns/op
```

### Benchmark w/ `value receiver`
```
BenchmarkCLevelDBRangeScans1M-12         	     121	  12516131 ns/op
BenchmarkCLevelDBRangeScans10M-12        	     114	  11823530 ns/op
BenchmarkCLevelDBRandomReadsWrites-12    	  174734	      7398 ns/op```