### PR TITLE
chore: revise goleveldb iterator

### DIFF
--- a/goleveldb/db.go
+++ b/goleveldb/db.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 
 	tmdb "github.com/line/tm-db/v2"
-	tmutil "github.com/line/tm-db/v2/internal/util"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/errors"
 	"github.com/syndtr/goleveldb/leveldb/opt"
@@ -172,12 +171,15 @@ func (db *GoLevelDB) Iterator(start, end []byte) (tmdb.Iterator, error) {
 		return nil, tmdb.ErrKeyEmpty
 	}
 	itr := db.db.NewIterator(&util.Range{Start: start, Limit: end}, nil)
-	return newGoLevelDBIterator(itr, start, end, false), nil
+	return newGoLevelDBIterator(itr, false), nil
 }
 
 func (db *GoLevelDB) PrefixIterator(prefix []byte) (tmdb.Iterator, error) {
-	start, end := tmutil.PrefixRange(prefix)
-	return db.Iterator(start, end)
+	if prefix != nil && len(prefix) == 0 {
+		return nil, tmdb.ErrKeyEmpty
+	}
+	itr := db.db.NewIterator(util.BytesPrefix(prefix), nil)
+	return newGoLevelDBIterator(itr, false), nil
 }
 
 // ReverseIterator implements DB.
@@ -186,10 +188,13 @@ func (db *GoLevelDB) ReverseIterator(start, end []byte) (tmdb.Iterator, error) {
 		return nil, tmdb.ErrKeyEmpty
 	}
 	itr := db.db.NewIterator(&util.Range{Start: start, Limit: end}, nil)
-	return newGoLevelDBIterator(itr, start, end, true), nil
+	return newGoLevelDBIterator(itr, true), nil
 }
 
 func (db *GoLevelDB) ReversePrefixIterator(prefix []byte) (tmdb.Iterator, error) {
-	start, end := tmutil.PrefixRange(prefix)
-	return db.ReverseIterator(start, end)
+	if prefix != nil && len(prefix) == 0 {
+		return nil, tmdb.ErrKeyEmpty
+	}
+	itr := db.db.NewIterator(util.BytesPrefix(prefix), nil)
+	return newGoLevelDBIterator(itr, true), nil
 }

--- a/goleveldb/db_test.go
+++ b/goleveldb/db_test.go
@@ -38,7 +38,7 @@ func TestGoLevelDBNewDBAndNewReadonlyDB(t *testing.T) {
 }
 
 func TestGoLevelDBStats(t *testing.T) {
-	name, dir := dbtest.NewTestName("cleveldb")
+	name, dir := dbtest.NewTestName("goleveldb")
 	db, err := NewDB(name, dir)
 	defer dbtest.CleanupDB(db, name, dir)
 	require.NoError(t, err)
@@ -62,6 +62,15 @@ func TestGoLevelDBEmptyIterator(t *testing.T) {
 	require.NoError(t, err)
 
 	dbtest.TestDBEmptyIterator(t, db)
+}
+
+func TestGoLevelDBPrefixIterator(t *testing.T) {
+	name, dir := dbtest.NewTestName("goleveldb")
+	db, err := NewDB(name, dir)
+	defer dbtest.CleanupDB(db, name, dir)
+	require.NoError(t, err)
+
+	dbtest.TestDBPrefixIterator(t, db)
 }
 
 func TestGoLevelDBPrefixIteratorNoMatchNil(t *testing.T) {

--- a/makefile
+++ b/makefile
@@ -56,7 +56,7 @@ bench-memdb:
 	@go test -bench=. ./memdb/... -tags memdb
 
 bench-goleveldb:
-	@go test -bench=. ./goleveldb/... -tags goleveldb -v
+	@go test -bench=. ./goleveldb/... -tags goleveldb
 
 bench-cleveldb:
 	@go test -bench=. ./cleveldb/... -tags cleveldb


### PR DESCRIPTION
Related with: #10, #11

### Motivation
* revise `goleveldb` `iterator` to be more simple, clear and performant.

### How to test
* make test-goleveldb

### Bechmark After
```
BenchmarkGoLevelDBRangeScans1M-12         	     825	   1408461 ns/op
BenchmarkGoLevelDBRangeScans10M-12        	     686	   1645930 ns/op
```

### Bechmark Before
```
BenchmarkGoLevelDBRangeScans1M-12         	     698	   1696691 ns/op
BenchmarkGoLevelDBRangeScans10M-12        	     609	   1898645 ns/op
```