### PR TITLE
chore: revise `PrefixRange()` to return err as well

### DIFF
--- a/badgerdb/db.go
+++ b/badgerdb/db.go
@@ -136,7 +136,10 @@ func (b *BadgerDB) Iterator(start, end []byte) (tmdb.Iterator, error) {
 }
 
 func (b *BadgerDB) PrefixIterator(prefix []byte) (tmdb.Iterator, error) {
-	start, end := util.PrefixRange(prefix)
+	start, end, err := util.PrefixRange(prefix)
+	if err != nil {
+		return nil, err
+	}
 	return b.Iterator(start, end)
 }
 
@@ -147,6 +150,9 @@ func (b *BadgerDB) ReverseIterator(start, end []byte) (tmdb.Iterator, error) {
 }
 
 func (b *BadgerDB) ReversePrefixIterator(prefix []byte) (tmdb.Iterator, error) {
-	start, end := util.PrefixRange(prefix)
+	start, end, err := util.PrefixRange(prefix)
+	if err != nil {
+		return nil, err
+	}
 	return b.ReverseIterator(start, end)
 }

--- a/badgerdb/db_test.go
+++ b/badgerdb/db_test.go
@@ -44,6 +44,15 @@ func TestBadgerDBEmptyIterator(t *testing.T) {
 	dbtest.TestDBEmptyIterator(t, db)
 }
 
+func TestBadgerDBPrefixIterator(t *testing.T) {
+	name, dir := dbtest.NewTestName("badgerdb")
+	db, err := NewDB(name, dir)
+	defer dbtest.CleanupDB(db, name, dir)
+	require.NoError(t, err)
+
+	dbtest.TestDBPrefixIterator(t, db)
+}
+
 func TestBadgerDBPrefixIteratorNoMatchNil(t *testing.T) {
 	name, dir := dbtest.NewTestName("badgerdb")
 	db, err := NewDB(name, dir)

--- a/boltdb/db.go
+++ b/boltdb/db.go
@@ -187,7 +187,10 @@ func (bdb *BoltDB) Iterator(start, end []byte) (tmdb.Iterator, error) {
 }
 
 func (bdb *BoltDB) PrefixIterator(prefix []byte) (tmdb.Iterator, error) {
-	start, end := util.PrefixRange(prefix)
+	start, end, err := util.PrefixRange(prefix)
+	if err != nil {
+		return nil, err
+	}
 	return bdb.Iterator(start, end)
 }
 
@@ -205,6 +208,9 @@ func (bdb *BoltDB) ReverseIterator(start, end []byte) (tmdb.Iterator, error) {
 }
 
 func (bdb *BoltDB) ReversePrefixIterator(prefix []byte) (tmdb.Iterator, error) {
-	start, end := util.PrefixRange(prefix)
+	start, end, err := util.PrefixRange(prefix)
+	if err != nil {
+		return nil, err
+	}
 	return bdb.ReverseIterator(start, end)
 }

--- a/boltdb/db_test.go
+++ b/boltdb/db_test.go
@@ -44,6 +44,15 @@ func TestBoltDBEmptyIterator(t *testing.T) {
 	dbtest.TestDBEmptyIterator(t, db)
 }
 
+func TestBoltDBPrefixIterator(t *testing.T) {
+	name, dir := dbtest.NewTestName("boltdb")
+	db, err := NewDB(name, dir)
+	defer dbtest.CleanupDB(db, name, dir)
+	require.NoError(t, err)
+
+	dbtest.TestDBPrefixIterator(t, db)
+}
+
 func TestBoltDBPrefixIteratorNoMatchNil(t *testing.T) {
 	name, dir := dbtest.NewTestName("boltdb")
 	db, err := NewDB(name, dir)

--- a/cleveldb/db.go
+++ b/cleveldb/db.go
@@ -184,7 +184,10 @@ func (db *CLevelDB) Iterator(start, end []byte) (tmdb.Iterator, error) {
 }
 
 func (db *CLevelDB) PrefixIterator(prefix []byte) (tmdb.Iterator, error) {
-	start, end := util.PrefixRange(prefix)
+	start, end, err := util.PrefixRange(prefix)
+	if err != nil {
+		return nil, err
+	}
 	return db.Iterator(start, end)
 }
 
@@ -198,6 +201,9 @@ func (db *CLevelDB) ReverseIterator(start, end []byte) (tmdb.Iterator, error) {
 }
 
 func (db *CLevelDB) ReversePrefixIterator(prefix []byte) (tmdb.Iterator, error) {
-	start, end := util.PrefixRange(prefix)
+	start, end, err := util.PrefixRange(prefix)
+	if err != nil {
+		return nil, err
+	}
 	return db.ReverseIterator(start, end)
 }

--- a/cleveldb/db_test.go
+++ b/cleveldb/db_test.go
@@ -44,6 +44,15 @@ func TestCLevelDBEmptyIterator(t *testing.T) {
 	dbtest.TestDBEmptyIterator(t, db)
 }
 
+func TestCLevelDBPrefixIterator(t *testing.T) {
+	name, dir := dbtest.NewTestName("cleveldb")
+	db, err := NewDB(name, dir)
+	defer dbtest.CleanupDB(db, name, dir)
+	require.NoError(t, err)
+
+	dbtest.TestDBPrefixIterator(t, db)
+}
+
 func TestCLevelDBPrefixIteratorNoMatchNil(t *testing.T) {
 	name, dir := dbtest.NewTestName("cleveldb")
 	db, err := NewDB(name, dir)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -3,6 +3,8 @@ package util
 import (
 	"bytes"
 	"os"
+
+	tmdb "github.com/line/tm-db/v2"
 )
 
 func Cp(bz []byte) (ret []byte) {
@@ -66,7 +68,11 @@ func FileExists(filePath string) bool {
 	return !os.IsNotExist(err)
 }
 
-func PrefixRange(prefix []byte) (start, end []byte) {
+func PrefixRange(prefix []byte) (start, end []byte, err error) {
+	if prefix != nil && len(prefix) == 0 {
+		return nil, nil, tmdb.ErrKeyEmpty
+	}
+
 	if len(prefix) == 0 {
 		start = nil
 		end = nil
@@ -74,7 +80,7 @@ func PrefixRange(prefix []byte) (start, end []byte) {
 		start = Cp(prefix)
 		end = CpIncr(prefix)
 	}
-	return start, end
+	return start, end, nil
 }
 
 // Path

--- a/memdb/db.go
+++ b/memdb/db.go
@@ -179,7 +179,10 @@ func (db *MemDB) Iterator(start, end []byte) (tmdb.Iterator, error) {
 }
 
 func (db *MemDB) PrefixIterator(prefix []byte) (tmdb.Iterator, error) {
-	start, end := util.PrefixRange(prefix)
+	start, end, err := util.PrefixRange(prefix)
+	if err != nil {
+		return nil, err
+	}
 	return db.Iterator(start, end)
 }
 
@@ -193,6 +196,9 @@ func (db *MemDB) ReverseIterator(start, end []byte) (tmdb.Iterator, error) {
 }
 
 func (db *MemDB) ReversePrefixIterator(prefix []byte) (tmdb.Iterator, error) {
-	start, end := util.PrefixRange(prefix)
+	start, end, err := util.PrefixRange(prefix)
+	if err != nil {
+		return nil, err
+	}
 	return db.ReverseIterator(start, end)
 }

--- a/memdb/db_test.go
+++ b/memdb/db_test.go
@@ -37,6 +37,48 @@ func TestMemDBEmptyIterator(t *testing.T) {
 	dbtest.TestDBEmptyIterator(t, db)
 }
 
+func TestMemDBPrefixIterator(t *testing.T) {
+	db := NewDB()
+	defer db.Close()
+
+	dbtest.TestDBPrefixIterator(t, db)
+}
+
+func TestMemDBPrefixIteratorNoMatchNil(t *testing.T) {
+	db := NewDB()
+	defer db.Close()
+
+	dbtest.TestPrefixIteratorNoMatchNil(t, db)
+}
+
+func TestMemDBPrefixIteratorNoMatch1(t *testing.T) {
+	db := NewDB()
+	defer db.Close()
+
+	dbtest.TestPrefixIteratorNoMatch1(t, db)
+}
+
+func TestMemDBPrefixIteratorNoMatch2(t *testing.T) {
+	db := NewDB()
+	defer db.Close()
+
+	dbtest.TestPrefixIteratorNoMatch2(t, db)
+}
+
+func TestMemDBPrefixIteratorMatch1(t *testing.T) {
+	db := NewDB()
+	defer db.Close()
+
+	dbtest.TestPrefixIteratorMatch1(t, db)
+}
+
+func TestMemDBPrefixIteratorMatches1N(t *testing.T) {
+	db := NewDB()
+	defer db.Close()
+
+	dbtest.TestPrefixIteratorMatches1N(t, db)
+}
+
 func TestMemDBBatch(t *testing.T) {
 	db := NewDB()
 	defer db.Close()

--- a/prefixdb/db.go
+++ b/prefixdb/db.go
@@ -136,7 +136,10 @@ func (pdb *PrefixDB) Iterator(start, end []byte) (tmdb.Iterator, error) {
 }
 
 func (pdb *PrefixDB) PrefixIterator(prefix []byte) (tmdb.Iterator, error) {
-	start, end := util.PrefixRange(prefix)
+	start, end, err := util.PrefixRange(prefix)
+	if err != nil {
+		return nil, err
+	}
 	return pdb.Iterator(start, end)
 }
 
@@ -164,7 +167,10 @@ func (pdb *PrefixDB) ReverseIterator(start, end []byte) (tmdb.Iterator, error) {
 }
 
 func (pdb *PrefixDB) ReversePrefixIterator(prefix []byte) (tmdb.Iterator, error) {
-	start, end := util.PrefixRange(prefix)
+	start, end, err := util.PrefixRange(prefix)
+	if err != nil {
+		return nil, err
+	}
 	return pdb.ReverseIterator(start, end)
 }
 

--- a/remotedb/db.go
+++ b/remotedb/db.go
@@ -116,7 +116,10 @@ func (rd *RemoteDB) Iterator(start, end []byte) (tmdb.Iterator, error) {
 }
 
 func (rd *RemoteDB) PrefixIterator(prefix []byte) (tmdb.Iterator, error) {
-	start, end := util.PrefixRange(prefix)
+	start, end, err := util.PrefixRange(prefix)
+	if err != nil {
+		return nil, err
+	}
 	return rd.Iterator(start, end)
 }
 
@@ -129,6 +132,9 @@ func (rd *RemoteDB) ReverseIterator(start, end []byte) (tmdb.Iterator, error) {
 }
 
 func (rd *RemoteDB) ReversePrefixIterator(prefix []byte) (tmdb.Iterator, error) {
-	start, end := util.PrefixRange(prefix)
+	start, end, err := util.PrefixRange(prefix)
+	if err != nil {
+		return nil, err
+	}
 	return rd.ReverseIterator(start, end)
 }

--- a/rocksdb/db.go
+++ b/rocksdb/db.go
@@ -189,7 +189,10 @@ func (db *RocksDB) Iterator(start, end []byte) (tmdb.Iterator, error) {
 }
 
 func (db *RocksDB) PrefixIterator(prefix []byte) (tmdb.Iterator, error) {
-	start, end := util.PrefixRange(prefix)
+	start, end, err := util.PrefixRange(prefix)
+	if err != nil {
+		return nil, err
+	}
 	return db.Iterator(start, end)
 }
 
@@ -203,6 +206,9 @@ func (db *RocksDB) ReverseIterator(start, end []byte) (tmdb.Iterator, error) {
 }
 
 func (db *RocksDB) ReversePrefixIterator(prefix []byte) (tmdb.Iterator, error) {
-	start, end := util.PrefixRange(prefix)
+	start, end, err := util.PrefixRange(prefix)
+	if err != nil {
+		return nil, err
+	}
 	return db.ReverseIterator(start, end)
 }

--- a/rocksdb/db_test.go
+++ b/rocksdb/db_test.go
@@ -35,6 +35,24 @@ func TestRocksDBIterator(t *testing.T) {
 	dbtest.TestDBIterator(t, db)
 }
 
+func TestRocksDBEmptyIterator(t *testing.T) {
+	name, dir := dbtest.NewTestName("rocksdb")
+	db, err := NewDB(name, dir)
+	defer dbtest.CleanupDB(db, name, dir)
+	require.NoError(t, err)
+
+	dbtest.TestDBEmptyIterator(t, db)
+}
+
+func TestRocksDBPrefixIterator(t *testing.T) {
+	name, dir := dbtest.NewTestName("rocksdb")
+	db, err := NewDB(name, dir)
+	defer dbtest.CleanupDB(db, name, dir)
+	require.NoError(t, err)
+
+	dbtest.TestDBPrefixIterator(t, db)
+}
+
 func TestRocksDBPrefixIteratorNoMatchNil(t *testing.T) {
 	name, dir := dbtest.NewTestName("rocksdb")
 	db, err := NewDB(name, dir)


### PR DESCRIPTION
Related with: #12 

### Motivation
* W/in #12, a new test, `TestDBPrefixIterator()`, is added.
* Apply this test to all db backends. For it, we need to revise `PrefixRange()` to return err as well.
* Add some missing test cases to `MemDB` and `RocksDB`.

### How to test
* make test-all