### PR TITLE
chore: optimize cleveldb iterator

### DIFF
--- a/cleveldb/db.go
+++ b/cleveldb/db.go
@@ -188,7 +188,8 @@ func (db *CLevelDB) PrefixIterator(prefix []byte) (tmdb.Iterator, error) {
 	if err != nil {
 		return nil, err
 	}
-	return db.Iterator(start, end)
+	itr := db.db.NewIterator(db.ro)
+	return newCLevelDBIterator(itr, start, end, false), nil
 }
 
 // ReverseIterator implements DB.
@@ -205,5 +206,6 @@ func (db *CLevelDB) ReversePrefixIterator(prefix []byte) (tmdb.Iterator, error) 
 	if err != nil {
 		return nil, err
 	}
-	return db.ReverseIterator(start, end)
+	itr := db.db.NewIterator(db.ro)
+	return newCLevelDBIterator(itr, start, end, true), nil
 }


### PR DESCRIPTION
### Motivation
* `cleveldb` iterator is relatively slow to `gleveldb` iterator due to `cgo` cost. 
* ref) https://about.sourcegraph.com/go/gophercon-2018-adventures-in-cgo-performance/
* reduce `cgo` calls by caching the result of `cgo` call.

### How to test
* make test-cleveldb
* make bench-cleveldb

### Benchmark After
```
BenchmarkCLevelDBRangeScans1M-12         	     271	   4240980 ns/op
BenchmarkCLevelDBRangeScans10M-12        	     250	   6344303 ns/op
```

### Benchmark Before
```
BenchmarkCLevelDBRangeScans1M-12         	     122	   9315653 ns/op
BenchmarkCLevelDBRangeScans10M-12        	     120	   9906077 ns/op
```