### PR TITLE
feat: add AvailableDBBackends function

### DIFF
--- a/metadb/db.go
+++ b/metadb/db.go
@@ -73,3 +73,11 @@ func NewDB(name string, backend BackendType, dir string) (tmdb.DB, error) {
 	}
 	return db, nil
 }
+
+func AvailableDBBackends() []BackendType {
+	registeredBackends := make([]BackendType, 0, len(backends))
+	for key := range backends {
+		registeredBackends = append(registeredBackends, key)
+	}
+	return registeredBackends
+}

--- a/metadb/db_test.go
+++ b/metadb/db_test.go
@@ -147,6 +147,14 @@ func TestDBIteratorNonemptyBeginAfter(t *testing.T) {
 	}
 }
 
+func TestAvailableDBBackends(t *testing.T) {
+	backendList := AvailableDBBackends()
+	assert.True(t, len(backends) == len(backendList))
+	for _, b := range backendList {
+		assert.NotNil(t, backends[b])
+	}
+}
+
 func newTempDB(t *testing.T, backend BackendType) (db tmdb.DB, name, dir string) {
 	name, dir = dbtest.NewTestName(fmt.Sprintf("%s", backend))
 	db, err := NewDB(name, backend, dir)


### PR DESCRIPTION
I added `AvailableDBBackends` function to know the specified db backend at build time in `ostracon` and `lbm-sdk` using `tm-db`. This function can be used in ostracon to determine the default DB backend.