### PR TITLE
chore: simplify prefixdb iterator and add tests

### DIFF
--- a/makefile
+++ b/makefile
@@ -36,17 +36,21 @@ test-badgerdb:
 	@echo "--> Running go test"
 	@go test ./badgerdb/... -tags badgerdb -v
 
+test-prefixdb:
+	@echo "--> Running go test"
+	@go test ./prefixdb/... -tags prefixdb -v
+
 test-remotedb:
 	@echo "--> Running go test"
 	@go test ./remotedb/... -tags goleveldb,remotedb -v
 
 test-all:
 	@echo "--> Running go test"
-	@go test $(PACKAGES) -tags memdb,goleveldb,cleveldb,boltdb,rocksdb,badgerdb,remotedb -v
+	@go test $(PACKAGES) -tags memdb,goleveldb,cleveldb,boltdb,rocksdb,badgerdb,prefixdb,remotedb -v
 
 test-all-docker:
 	@echo "--> Running go test"
-	@docker run --rm -v $(CURDIR):/workspace --workdir /workspace tendermintdev/docker-tm-db-testing go test $(PACKAGES) -tags memdb,goleveldb,cleveldb,boltdb,rocksdb,badgerdb,remotedb -v
+	@docker run --rm -v $(CURDIR):/workspace --workdir /workspace tendermintdev/docker-tm-db-testing go test $(PACKAGES) -tags memdb,goleveldb,cleveldb,boltdb,rocksdb,badgerdb,prefixdb,remotedb -v
 .PHONY: test-all-docker
 
 bench:
@@ -70,14 +74,17 @@ bench-boltdb:
 bench-badgerdb:
 	@go test -bench=. ./badgerdb/... -tags badgerdb
 
+bench-prefixdb:
+	@go test -bench=. ./prefixdb/... -tags prefixdb
+
 bench-remotedb:
 	@go test -bench=. ./remotedb/... -tags goleveldb,remotedb
 
 bench-all:
-	@go test -bench=. $(PACKAGES) -tags memdb,goleveldb,cleveldb,boltdb,rocksdb,badgerdb,remotedb
+	@go test -bench=. $(PACKAGES) -tags memdb,goleveldb,cleveldb,boltdb,rocksdb,badgerdb,prefixdb,remotedb
 
 bench-all-docker:
-	@docker run --rm -v $(CURDIR):/workspace --workdir /workspace tendermintdev/docker-tm-db-testing go test -bench=. $(PACKAGES) -tags memdb,goleveldb,cleveldb,boltdb,rocksdb,badgerdb,remotedb
+	@docker run --rm -v $(CURDIR):/workspace --workdir /workspace tendermintdev/docker-tm-db-testing go test -bench=. $(PACKAGES) -tags memdb,goleveldb,cleveldb,boltdb,rocksdb,badgerdb,prefixdb,remotedb
 .PHONY: bench-all-docker
 
 lint:

--- a/prefixdb/db_test.go
+++ b/prefixdb/db_test.go
@@ -1,3 +1,5 @@
+// +build prefixdb
+
 package prefixdb_test
 
 import (
@@ -7,6 +9,7 @@ import (
 	"github.com/line/tm-db/v2/internal/dbtest"
 	"github.com/line/tm-db/v2/memdb"
 	"github.com/line/tm-db/v2/prefixdb"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -113,4 +116,175 @@ func TestPrefixDBReverseIterator7(t *testing.T) {
 	dbtest.Next(t, itr, false)
 	dbtest.Invalid(t, itr)
 	itr.Close()
+}
+
+func TestPrefixDBNewDB(t *testing.T) {
+	db := memdb.NewDB()
+	require.NotNil(t, db)
+	defer db.Close()
+	pdb := prefixdb.NewDB(db, []byte("key"))
+	require.NotNil(t, pdb)
+	defer pdb.Close()
+
+	require.Panics(t, func() {
+		prefixdb.NewDB(db, []byte{})
+	})
+
+	require.Panics(t, func() {
+		prefixdb.NewDB(db, nil)
+	})
+}
+
+func TestPrefixDBStats(t *testing.T) {
+	db := memdb.NewDB()
+	require.NotNil(t, db)
+	defer db.Close()
+	pdb := prefixdb.NewDB(db, []byte("key"))
+	require.NotNil(t, pdb)
+	defer pdb.Close()
+
+	assert.NotEmpty(t, pdb.Stats())
+}
+
+func TestPrefixDBIterator(t *testing.T) {
+	db := memdb.NewDB()
+	require.NotNil(t, db)
+	defer db.Close()
+	pdb := prefixdb.NewDB(db, []byte("key"))
+	require.NotNil(t, pdb)
+	defer pdb.Close()
+
+	dbtest.TestDBIterator(t, pdb)
+}
+
+func TestPrefixDBIteratorNoWrites(t *testing.T) {
+	db := memdb.NewDB()
+	require.NotNil(t, db)
+	defer db.Close()
+	pdb := prefixdb.NewDB(db, []byte("key"))
+	require.NotNil(t, pdb)
+	defer pdb.Close()
+
+	dbtest.TestDBIteratorNoWrites(t, pdb)
+}
+
+func TestPrefixDBEmptyIterator(t *testing.T) {
+	db := memdb.NewDB()
+	require.NotNil(t, db)
+	defer db.Close()
+	pdb := prefixdb.NewDB(db, []byte("key"))
+	require.NotNil(t, pdb)
+	defer pdb.Close()
+
+	dbtest.TestDBEmptyIterator(t, pdb)
+}
+
+func TestPrefixDBPrefixIterator(t *testing.T) {
+	db := memdb.NewDB()
+	require.NotNil(t, db)
+	defer db.Close()
+	pdb := prefixdb.NewDB(db, []byte("key"))
+	require.NotNil(t, pdb)
+	defer pdb.Close()
+
+	dbtest.TestDBPrefixIterator(t, pdb)
+}
+
+func TestPrefixDBPrefixIteratorNoMatchNil(t *testing.T) {
+	db := memdb.NewDB()
+	require.NotNil(t, db)
+	defer db.Close()
+	pdb := prefixdb.NewDB(db, []byte("key"))
+	require.NotNil(t, pdb)
+	defer pdb.Close()
+
+	dbtest.TestPrefixIteratorNoMatchNil(t, pdb)
+}
+
+func TestPrefixDBPrefixIteratorNoMatch1(t *testing.T) {
+	db := memdb.NewDB()
+	require.NotNil(t, db)
+	defer db.Close()
+	pdb := prefixdb.NewDB(db, []byte("key"))
+	require.NotNil(t, pdb)
+	defer pdb.Close()
+
+	dbtest.TestPrefixIteratorNoMatch1(t, pdb)
+}
+
+func TestPrefixDBPrefixIteratorNoMatch2(t *testing.T) {
+	db := memdb.NewDB()
+	require.NotNil(t, db)
+	defer db.Close()
+	pdb := prefixdb.NewDB(db, []byte("key"))
+	require.NotNil(t, pdb)
+	defer pdb.Close()
+
+	dbtest.TestPrefixIteratorNoMatch2(t, pdb)
+}
+
+func TestPrefixDBPrefixIteratorMatch1(t *testing.T) {
+	db := memdb.NewDB()
+	require.NotNil(t, db)
+	defer db.Close()
+	pdb := prefixdb.NewDB(db, []byte("key"))
+	require.NotNil(t, pdb)
+	defer pdb.Close()
+
+	dbtest.TestPrefixIteratorMatch1(t, pdb)
+}
+
+func TestPrefixDBPrefixIteratorMatches1N(t *testing.T) {
+	db := memdb.NewDB()
+	require.NotNil(t, db)
+	defer db.Close()
+	pdb := prefixdb.NewDB(db, []byte("key"))
+	require.NotNil(t, pdb)
+	defer pdb.Close()
+
+	dbtest.TestPrefixIteratorMatches1N(t, pdb)
+}
+
+func TestPrefixDBBatch(t *testing.T) {
+	db := memdb.NewDB()
+	require.NotNil(t, db)
+	defer db.Close()
+	pdb := prefixdb.NewDB(db, []byte("key"))
+	require.NotNil(t, pdb)
+	defer pdb.Close()
+
+	dbtest.TestDBBatch(t, pdb)
+}
+
+func BenchmarkPrefixDBRangeScans1M(b *testing.B) {
+	db := memdb.NewDB()
+	require.NotNil(b, db)
+	defer db.Close()
+	pdb := prefixdb.NewDB(db, []byte("key"))
+	require.NotNil(b, pdb)
+	defer pdb.Close()
+
+	dbtest.BenchmarkRangeScans(b, pdb, int64(1e6))
+}
+
+func BenchmarkPrefixDBRangeScans10M(b *testing.B) {
+	db := memdb.NewDB()
+	require.NotNil(b, db)
+	defer db.Close()
+	pdb := prefixdb.NewDB(db, []byte("key"))
+	require.NotNil(b, pdb)
+	defer pdb.Close()
+
+	dbtest.BenchmarkRangeScans(b, pdb, int64(10e6))
+}
+
+func BenchmarkPrefixDBRandomReadsWrites(b *testing.B) {
+	db := memdb.NewDB()
+	require.NotNil(b, db)
+	defer db.Close()
+	pdb := prefixdb.NewDB(db, []byte("key"))
+	require.NotNil(b, pdb)
+	defer pdb.Close()
+
+	dbtest.BenchmarkRandomReadsWrites(b, pdb)
 }


### PR DESCRIPTION
### Motivation
* simplify prefixdb iterator because most condition is already checked from `source` db iterator.
* add prefixdb tests to follow up test convention.

### How to test
* make test-prefixdb
* make bench-prefixdb

### Benchmark `prefixdb` iterator backed by `memdb`
* It spends only insignificant cost compared to `memdb` iterator
```
BenchmarkPrefixDBRangeScans1M-12         	     813	   1471581 ns/op
BenchmarkPrefixDBRangeScans10M-12        	     802	   1515243 ns/op
```

### Benchmark `memdb` iterator
```
BenchmarkMemDBRangeScans1M-12         	     846	   1415446 ns/op
BenchmarkMemDBRangeScans10M-12        	     834	   1498702 ns/op
```