### PR TITLE
fix: register goleveldb for db_backend by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
   Test:
     runs-on: ubuntu-latest
-    container: tendermintdev/docker-tm-db-testing
+    container: lbmdev/docker-tm-db-testing
     steps:
       - uses: actions/checkout@v2
       - name: test & coverage report creation

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,6 @@
 name: Build & Push TM-DB-Testing
 on:
-  pull-request:
+  pull_request:
     branches:
       - main
     paths:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,5 @@
 name: Build & Push TM-DB-Testing
 on:
-  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,6 @@
 name: Build & Push TM-DB-Testing
 on:
   pull_request:
-    paths:
-      - "tools/*"
   push:
     branches:
       - master

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,10 @@
 name: Build & Push TM-DB-Testing
 on:
+  pull-request:
+    branches:
+      - main
+    paths:
+      - "tools/*"
   push:
     branches:
       - master
@@ -14,7 +19,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=tendermintdev/docker-tm-db-testing
+          DOCKER_IMAGE=lbmdev/docker-tm-db-testing
           VERSION=noop
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   golangci:
     runs-on: ubuntu-latest
-    container: tendermintdev/docker-tm-db-testing
+    container: lbmdev/docker-tm-db-testing
     steps:
       - uses: actions/checkout@v2
       - uses: golangci/golangci-lint-action@v2.4.0

--- a/metadb/db_goleveldb.go
+++ b/metadb/db_goleveldb.go
@@ -1,5 +1,3 @@
-// +build goleveldb
-
 package metadb
 
 import (

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -20,11 +20,11 @@ RUN \
 
 # Install Rocksdb
 RUN \
-  wget https://github.com/facebook/rocksdb/archive/v6.6.4.tar.gz \
-  && tar -zxf v6.6.4.tar.gz \
-  && cd rocksdb-6.6.4 \
+  wget https://github.com/facebook/rocksdb/archive/v6.20.3.tar.gz \
+  && tar -zxf v6.20.3.tar.gz \
+  && cd rocksdb-6.20.3 \
   && DEBUG_LEVEL=0 make -j4 shared_lib \
   && make install-shared \
   && ldconfig \
   && cd .. \
-  && rm -rf v6.6.4.tar.gz rocksdb-6.6.4
+  && rm -rf v6.20.3.tar.gz rocksdb-6.20.3


### PR DESCRIPTION
At least one db_backend type must be specified with the build tag when building `lfb`, `lfb-sdk`, `ostracon`, etc. using `line/tm-db`. Currently, `lfb`, `lfb-sdk` automatically includes the `goleveldb` option, but when developing a new app, there is the inconvenience of putting all of these options. This also applies to ostracon test scripts. There is also the inconvenience of having to include this option when running tests in the `Goland`. So I want to register the default db backend(goleveldb) of `tm-db`.