### PR TITLE
fix: use default db backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Test
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 jobs:
   cleanup-runs:
@@ -15,7 +15,11 @@ jobs:
 
   Test:
     runs-on: ubuntu-latest
-    container: tendermintdev/docker-tm-db-testing
+    container:
+      image: line/tm-db-testing
+      credentials:
+         username: ${{ secrets.DOCKERHUB_USERNAME }}
+         password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - name: test & coverage report creation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: rokroskar/workflow-run-cleanup-action@master
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main'"
 
   Test:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,13 @@
 name: Build & Push TM-DB-Testing
 on:
   pull_request:
+    branches:
+      - main
     paths:
       - "tools/*"
   push:
     branches:
-      - master
+      - main
     paths:
       - "tools/*"
 
@@ -17,8 +19,8 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=tendermintdev/docker-tm-db-testing
-          VERSION=noop
+          DOCKER_IMAGE=line/tm-db-testing
+          VERSION=latest
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
           elif [[ $GITHUB_REF == refs/heads/* ]]; then
@@ -33,7 +35,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -46,3 +57,11 @@ jobs:
           file: ./tools/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,13 +2,17 @@ name: Lint
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:
   golangci:
     runs-on: ubuntu-latest
-    container: tendermintdev/docker-tm-db-testing
+    container:
+      image: line/tm-db-testing
+      credentials:
+         username: ${{ secrets.DOCKERHUB_USERNAME }}
+         password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - uses: golangci/golangci-lint-action@v2.4.0

--- a/internal/dbtest/helper.go
+++ b/internal/dbtest/helper.go
@@ -222,7 +222,8 @@ func TestDBIteratorNoWrites(t *testing.T, db tmdb.DB) {
 	err = db.Set(Int642Bytes(int64(6)), []byte{})
 	require.NoError(t, err)
 
-	exist6, err := db.Has(Int642Bytes(int64(6)))
+	exist6, err2 := db.Has(Int642Bytes(int64(6)))
+	require.NoError(t, err2)
 	require.True(t, exist6)
 
 	verifyAndCloseIterator(t, itr, []int64{0, 1, 2, 3, 4, 5, 7, 8, 9}, "forward iterator")

--- a/metadb/db_goleveldb.go
+++ b/metadb/db_goleveldb.go
@@ -1,5 +1,3 @@
-// +build goleveldb
-
 package metadb
 
 import (

--- a/metadb/db_test.go
+++ b/metadb/db_test.go
@@ -156,7 +156,7 @@ func TestAvailableDBBackends(t *testing.T) {
 }
 
 func newTempDB(t *testing.T, backend BackendType) (db tmdb.DB, name, dir string) {
-	name, dir = dbtest.NewTestName(fmt.Sprintf("%s", backend))
+	name, dir = dbtest.NewTestName(string(backend))
 	db, err := NewDB(name, backend, dir)
 	require.NoError(t, err)
 	return db, name, dir

--- a/prefixdb/iterator.go
+++ b/prefixdb/iterator.go
@@ -2,6 +2,7 @@ package prefixdb
 
 import (
 	"bytes"
+
 	tmdb "github.com/line/tm-db/v2"
 )
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -20,11 +20,11 @@ RUN \
 
 # Install Rocksdb
 RUN \
-  wget https://github.com/facebook/rocksdb/archive/v6.6.4.tar.gz \
-  && tar -zxf v6.6.4.tar.gz \
-  && cd rocksdb-6.6.4 \
+  wget https://github.com/facebook/rocksdb/archive/v6.20.3.tar.gz \
+  && tar -zxf v6.20.3.tar.gz \
+  && cd rocksdb-6.20.3 \
   && DEBUG_LEVEL=0 make -j4 shared_lib \
   && make install-shared \
   && ldconfig \
   && cd .. \
-  && rm -rf v6.6.4.tar.gz rocksdb-6.6.4
+  && rm -rf v6.20.3.tar.gz rocksdb-6.20.3


### PR DESCRIPTION
At least one db_backend type must be specified with the build tag when building lfb, lfb-sdk, ostracon, etc. using line/tm-db. Currently, lfb, lfb-sdk automatically includes the goleveldb option, but when developing a new app, there is the inconvenience of putting all of these options. This also applies to ostracon test scripts. There is also the inconvenience of having to include this option when running tests in the Goland. So I want to register the default db backend(goleveldb) of tm-db.