### PR TITLE
fix: add memdb to default db backend

### DIFF
--- a/metadb/db_memdb.go
+++ b/metadb/db_memdb.go
@@ -1,5 +1,3 @@
-// +build memdb
-
 package metadb
 
 import (


### PR DESCRIPTION
Added memdb to default db backend because ostracon test suites uses it.