### PR TITLE
fix: should use copied value of iterator

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,8 @@ jobs:
     container:
       image: line/tm-db-testing
       credentials:
-         username: ${{ secrets.DOCKERHUB_USERNAME }}
-         password: ${{ secrets.TOKEN }}
+         username: yyyyy
+         password: xxxxx
     steps:
       - uses: actions/checkout@v2
       - uses: golangci/golangci-lint-action@v2.4.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     container:
       image: line/tm-db-testing
       credentials:
-         username: ${{ secrets.github_token }}
+         username: ${{ secrets.DOCKERHUB_USERNAME }}
          password: xxxxx
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     container:
       image: line/tm-db-testing
       credentials:
-         username: ${{ secrets.DOCKERHUB_USERNAME }}
+         username: ${{ secrets.token }}
          password: xxxxx
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     container:
       image: line/tm-db-testing
       credentials:
-         username: yyyyy
+         username: ${{ secrets.github_token }}
          password: xxxxx
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
       image: line/tm-db-testing
       credentials:
          username: ${{ secrets.DOCKERHUB_USERNAME }}
-         password: ${{ secrets.DOCKERHUB_TOKEN }}
+         password: ${{ secrets.TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - uses: golangci/golangci-lint-action@v2.4.0

--- a/rocksdb/db.go
+++ b/rocksdb/db.go
@@ -69,7 +69,11 @@ func (db *RocksDB) Get(key []byte) ([]byte, error) {
 	if len(key) == 0 {
 		return nil, tmdb.ErrKeyEmpty
 	}
-	return db.db.GetBytes(db.ro, key)
+	res, err := db.db.Get(db.ro, key)
+	if err != nil {
+		return nil, err
+	}
+	return moveSliceToBytes(res), nil
 }
 
 // Has implements DB.


### PR DESCRIPTION
We found the cause of this system crash(https://github.com/line/lbm-sdk/issues/314).

In this PR(https://github.com/line/tm-db/pull/22), it was modified not to copy when getting a value from an iterator, but this code has a problem.

In rocksdb, `iterator.value` is a memory within db, so we don't know when it will be free. Therefore, it must be copied and used.
