### PR TITLE
fix: should use copied value of iterator

### DIFF
--- a/rocksdb/db.go
+++ b/rocksdb/db.go
@@ -69,11 +69,7 @@ func (db *RocksDB) Get(key []byte) ([]byte, error) {
 	if len(key) == 0 {
 		return nil, tmdb.ErrKeyEmpty
 	}
-	res, err := db.db.Get(db.ro, key)
-	if err != nil {
-		return nil, err
-	}
-	return moveSliceToBytes(res), nil
+	return db.db.GetBytes(db.ro, key)
 }
 
 // Has implements DB.

--- a/rocksdb/db.go
+++ b/rocksdb/db.go
@@ -69,7 +69,11 @@ func (db *RocksDB) Get(key []byte) ([]byte, error) {
 	if len(key) == 0 {
 		return nil, tmdb.ErrKeyEmpty
 	}
-	return db.db.GetBytes(db.ro, key)
+	res, err := db.db.Get(db.ro, key)
+	if err != nil {
+		return nil, err
+	}
+	return moveSliceToBytes(res), nil
 }
 
 // Has implements DB.


### PR DESCRIPTION
We found the cause of this system crash(line/lbm-sdk#314).

In this PR(#22), it was modified not to copy when getting a value from an iterator, but this code has a problem.

In rocksdb, iterator.value is a memory within db, so we don't know when it will be free. Therefore, it must be copied and used.