### PR TITLE
Re-update the Docker image with rocksdb-v6.20.3

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-# CODEOWNERS: https://help.github.com/articles/about-codeowners/
-
-*       @alexanderbez @cmwaters @creachadair @marbar3778 @tychoish @williambanfield

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,17 @@ jobs:
     container:
       image: line/tm-db-testing
       credentials:
-         username: ${{ secrets.DOCKERHUB_USERNAME }}
-         password: ${{ secrets.DOCKERHUB_TOKEN }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
       - uses: actions/checkout@v2
       - name: test & coverage report creation
         run: |
-          CGO_LDFLAGS=-lrocksdb go test ./... -mod=readonly -timeout 8m -race -coverprofile=coverage.txt -covermode=atomic -tags=memdb,goleveldb,cleveldb,boltdb,rocksdb,badgerdb -v
+          go test ./... -mod=readonly -timeout 8m -race -coverprofile=coverage.txt -covermode=atomic \
+          -tags=cleveldb,boltdb,badgerdb -v # ignore rocksdb
       - uses: codecov/codecov-action@v2.0.3
         with:
           file: ./coverage.txt

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,5 @@
 # This workflow builds and pushes a new version of the build container image
-# when the tools directory changes on master. Edit tools/Dockerfile.
+# when the tools directory changes on main. Edit tools/Dockerfile.
 #
 # This workflow does not push a new image until it is merged, so tests that
 # depend on changes in this image will not pass until this workflow succeeds.
@@ -61,7 +61,7 @@ jobs:
       - name: Publish to Docker Hub
         uses: docker/build-push-action@v2
         with:
-          context: ./tools
+          context: .
           file: ./tools/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
@@ -72,4 +72,3 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,11 +12,13 @@ on:
     branches:
       - main
     paths:
+      - "contrib/*"
       - "tools/*"
   push:
     branches:
       - main
     paths:
+      - "contrib/*"
       - "tools/*"
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,15 +13,18 @@ jobs:
     container:
       image: line/tm-db-testing
       credentials:
-         username: ${{ secrets.DOCKERHUB_USERNAME }}
-         password: ${{ secrets.DOCKERHUB_TOKEN }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
       - uses: actions/checkout@v2
-      - uses: golangci/golangci-lint-action@v2.5.2
+      - uses: golangci/golangci-lint-action@v3.1.0
         with:
           # Required: the version of golangci-lint is required and must be
           # specified without patch version: we always use the latest patch
           # version.
-          version: v1.30
-          args: --timeout 10m --build-tags "badgerdb,boltdb,goleveldb,memdb,remotedb,prefixdb"
+          version: v1.42.1
+          args: --timeout 10m --build-tags "cleveldb,boltdb,badgerdb" # ignore rocksdb
           github-token: ${{ secrets.github_token }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@
 
 .idea
 vendor/*
+
+##########
+
+/leveldb*
+/rocksdb*
+/test_*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 been reverted to flat directory structure in v0.6.6. 
 
 ### Breaking Changes
-* (line/tm-db) [\36](https://github.com/line/tm-db/pull/36) Merge v0.6.6
+* (line/tm-db) [\#36](https://github.com/line/tm-db/pull/36) Merge v0.6.6
 
 **2021-11-08**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Please don't make Pull Requests from `main`.
 
 ## Dependencies
 
-We use [Go 1.15 Modules](https://github.com/golang/go/wiki/Modules) to manage
+We use [Go 1.16 Modules](https://github.com/golang/go/wiki/Modules) to manage
 dependency versions.
 
 The `main` branch of every LFB repository should just build with `go get`,

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Forked Tendermint DB for LFB SDK and Ostracon 
+# Forked Tendermint DB for LBM SDK and Ostracon 
 
-Common database interface for various database backends. This is forked for applications built on [Ostracon](https://github.com/line/ostracon), such as the [LFB SDK](https://github.com/line/lfb-sdk) from [Tendermint tm-db](https://github.com/tendermint/tm-db), but can be used independently of these as well.
+Common database interface for various database backends. This is forked for applications built on [Ostracon](https://github.com/line/ostracon), such as the [LBM SDK](https://github.com/line/lbm-sdk) from [Tendermint tm-db](https://github.com/tendermint/tm-db), but can be used independently of these as well.
 
 ### Minimum Go Version
 
-Go 1.15+
+Go 1.16+
 
 ## Supported Database Backends
 

--- a/badger_db.go
+++ b/badger_db.go
@@ -1,3 +1,4 @@
+//go:build badgerdb
 // +build badgerdb
 
 package db

--- a/boltdb.go
+++ b/boltdb.go
@@ -1,3 +1,4 @@
+//go:build boltdb
 // +build boltdb
 
 package db

--- a/boltdb_batch.go
+++ b/boltdb_batch.go
@@ -1,3 +1,4 @@
+//go:build boltdb
 // +build boltdb
 
 package db

--- a/boltdb_iterator.go
+++ b/boltdb_iterator.go
@@ -1,3 +1,4 @@
+//go:build boltdb
 // +build boltdb
 
 package db

--- a/boltdb_test.go
+++ b/boltdb_test.go
@@ -1,3 +1,4 @@
+//go:build boltdb
 // +build boltdb
 
 package db

--- a/cleveldb.go
+++ b/cleveldb.go
@@ -1,3 +1,4 @@
+//go:build cleveldb
 // +build cleveldb
 
 package db

--- a/cleveldb_batch.go
+++ b/cleveldb_batch.go
@@ -1,3 +1,4 @@
+//go:build cleveldb
 // +build cleveldb
 
 package db

--- a/cleveldb_iterator.go
+++ b/cleveldb_iterator.go
@@ -1,3 +1,4 @@
+//go:build cleveldb
 // +build cleveldb
 
 package db

--- a/cleveldb_test.go
+++ b/cleveldb_test.go
@@ -1,3 +1,4 @@
+//go:build cleveldb
 // +build cleveldb
 
 package db
@@ -54,7 +55,7 @@ func BenchmarkRandomReadsWrites2(b *testing.B) {
 			if err != nil {
 				b.Error(err)
 			}
-			//fmt.Printf("Get %X -> %X\n", idxBytes, valBytes)
+			// fmt.Printf("Get %X -> %X\n", idxBytes, valBytes)
 			if val == 0 {
 				if !bytes.Equal(valBytes, nil) {
 					b.Errorf("Expected %v for %v, got %X",

--- a/contrib/get_cleveldb.sh
+++ b/contrib/get_cleveldb.sh
@@ -1,10 +1,10 @@
 set -e
 
-version="1.23"
+version="1.20"
 leveldb="leveldb"
-archive="${version}.tar.gz"
+archive="v${version}.tar.gz"
 
 rm -rf ${leveldb} ${leveldb}-${archive}
-wget -O ${leveldb}-${archive} https://github.com/google/leveldb/archive/${archive}
+wget -q -O ${leveldb}-${archive} https://github.com/google/leveldb/archive/${archive}
 tar -zxvf ${leveldb}-${archive}
 mv ${leveldb}-${version} ${leveldb}

--- a/contrib/get_rocksdb.sh
+++ b/contrib/get_rocksdb.sh
@@ -2,10 +2,9 @@ set -e
 
 version="6.20.3"
 rocksdb="rocksdb"
-rocksdb_dir="rocksdb.build"
 archive="v${version}.tar.gz"
 
-rm -rf ${rocksdb_dir} ${rocksdb}-${archive}
-wget -O ${rocksdb}-${archive} https://github.com/facebook/rocksdb/archive/${archive}
+rm -rf ${rocksdb} ${rocksdb}-${archive}
+wget -q -O ${rocksdb}-${archive} https://github.com/facebook/rocksdb/archive/${archive}
 tar -zxvf ${rocksdb}-${archive}
-mv ${rocksdb}-${version} ${rocksdb_dir}
+mv ${rocksdb}-${version} ${rocksdb}

--- a/makefile
+++ b/makefile
@@ -2,10 +2,16 @@ GOTOOLS = github.com/golangci/golangci-lint/cmd/golangci-lint
 PACKAGES=$(shell go list ./...)
 INCLUDE = -I=. -I=${GOPATH}/src -I=${GOPATH}/src/github.com/gogo/protobuf/protobuf
 
+# Setup
+# See: LevelDB: https://github.com/jmhodges/levigo/blob/master/README.md
+# See: RocksDB: https://github.com/line/gorocksdb/blob/main/README.md
 CLEVELDB_DIR=$(shell pwd)/leveldb
-ROCKSDB_DIR=$(shell pwd)/rocksdb.build
+ROCKSDB_DIR=$(shell pwd)/rocksdb
 CGO_CFLAGS=-I$(CLEVELDB_DIR)/include -I$(ROCKSDB_DIR)/include
-CGO_LDFLAGS=-L$(CLEVELDB_DIR)/build -L$(ROCKSDB_DIR) -lleveldb -lrocksdb -lm -lstdc++ $(shell awk '/PLATFORM_LDFLAGS/ {sub("PLATFORM_LDFLAGS=", ""); print}' < $(ROCKSDB_DIR)/make_config.mk)
+CGO_LDFLAGS=-L$(CLEVELDB_DIR) -L$(ROCKSDB_DIR) -lleveldb -lrocksdb -lm -lstdc++ $(shell awk '/PLATFORM_LDFLAGS/ {sub("PLATFORM_LDFLAGS=", ""); print}' < $(ROCKSDB_DIR)/make_config.mk)
+
+DOCKER_NAME=tm-db-testing
+DOCKER_IMAGE=line/$(DOCKER_NAME)
 
 export GO111MODULE = on
 
@@ -13,30 +19,19 @@ all: lint test
 
 ### go tests
 ## By default this will only test memdb & goleveldb
-test: cleveldb rocksdb.build
+test:
+	@echo "--> Running go test"
+	@go test $(PACKAGES) -v
+
+test-cleveldb: build-cleveldb
 	@echo "--> Running go test"
 	@CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
-		go test $(PACKAGES) -tags memdb,goleveldb -v
+	go test $(PACKAGES) -tags cleveldb -v
 
-test-memdb:
+test-rocksdb: build-rocksdb
 	@echo "--> Running go test"
-	@go test $(PACKAGES) -tags memdb -v
-
-test-goleveldb:
-	@echo "--> Running go test"
-	@go test $(PACKAGES) -tags goleveldb -v
-
-test-cleveldb:
-	@echo "--> Running go test"
-	@go test $(PACKAGES) -tags cleveldb -v
-
-test-rocksdb:
-	@echo "--> Running go test"
-	@go test $(PACKAGES) -tags rocksdb -v
-
-test-rdb:
-	@echo "--> Running go test"
-	@go test $(PACKAGES) -tags rocksdb -v
+	@CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
+	go test $(PACKAGES) -tags rocksdb -v
 
 test-boltdb:
 	@echo "--> Running go test"
@@ -46,37 +41,27 @@ test-badgerdb:
 	@echo "--> Running go test"
 	@go test $(PACKAGES) -tags badgerdb -v
 
-test-prefixdb:
+test-all: build-cleveldb build-rocksdb
 	@echo "--> Running go test"
-	@go test $(PACKAGES) -tags prefixdb -v
-
-test-remotedb:
-	@echo "--> Running go test"
-	@go test $(PACKAGES) -tags goleveldb,remotedb -v
-
-test-all:
-	@echo "--> Running go test"
-	@go test $(PACKAGES) -tags memdb,goleveldb,cleveldb,boltdb,rocksdb,badgerdb,prefixdb,remotedb -v
+	@CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
+	go test $(PACKAGES) -tags cleveldb,rocksdb,boltdb,badgerdb -v
 
 test-all-docker:
 	@echo "--> Running go test"
-	@docker run --rm -v $(CURDIR):/workspace --workdir /workspace tendermintdev/docker-tm-db-testing go test $(PACKAGES) -tags memdb,goleveldb,cleveldb,boltdb,rocksdb,badgerdb,prefixdb,remotedb -v
+	@docker run --rm -e CGO_LDFLAGS="-lrocksdb" -v $(CURDIR):/workspace --workdir /workspace $(DOCKER_IMAGE) \
+	go test $(PACKAGES) -tags cleveldb,rocksdb,boltdb,badgerdb -v
 .PHONY: test-all-docker
 
 bench:
-	@go test -bench=. $(PACKAGES) -tags memdb,goleveldb
+	@go test -bench=. $(PACKAGES)
 
-bench-memdb:
-	@go test -bench=. $(PACKAGES) -tags memdb
+bench-cleveldb: build-cleveldb
+	@CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
+	go test -bench=. $(PACKAGES) -tags cleveldb
 
-bench-goleveldb:
-	@go test -bench=. $(PACKAGES) -tags goleveldb
-
-bench-cleveldb:
-	@go test -bench=. $(PACKAGES) -tags cleveldb
-
-bench-rocksdb:
-	@go test -bench=. $(PACKAGES) -tags rocksdb
+bench-rocksdb: build-rocksdb
+	@CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
+	go test -bench=. $(PACKAGES) -tags rocksdb
 
 bench-boltdb:
 	@go test -bench=. $(PACKAGES) -tags boltdb
@@ -84,17 +69,13 @@ bench-boltdb:
 bench-badgerdb:
 	@go test -bench=. $(PACKAGES) -tags badgerdb
 
-bench-prefixdb:
-	@go test -bench=. $(PACKAGES) -tags prefixdb
-
-bench-remotedb:
-	@go test -bench=. $(PACKAGES) -tags goleveldb,remotedb
-
-bench-all:
-	@go test -bench=. $(PACKAGES) -tags memdb,goleveldb,cleveldb,boltdb,rocksdb,badgerdb,prefixdb,remotedb
+bench-all: build-cleveldb build-rocksdb
+	@CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
+	go test -bench=. $(PACKAGES) -tags cleveldb,rocksdb,boltdb,badgerdb
 
 bench-all-docker:
-	@docker run --rm -v $(CURDIR):/workspace --workdir /workspace tendermintdev/docker-tm-db-testing go test -bench=. $(PACKAGES) -tags memdb,goleveldb,cleveldb,boltdb,rocksdb,badgerdb,prefixdb,remotedb
+	@docker run --rm -e CGO_LDFLAGS="-lrocksdb" -v $(CURDIR):/workspace --workdir /workspace $(DOCKER_IMAGE) \
+	go test -bench=. $(PACKAGES) -tags cleveldb,rocksdb,boltdb,badgerdb
 .PHONY: bench-all-docker
 
 lint:
@@ -102,6 +83,13 @@ lint:
 	@golangci-lint run
 	@go mod verify
 .PHONY: lint
+
+lint-all: build-cleveldb build-rocksdb
+	@echo "--> Running linter"
+	@CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
+	golangci-lint run --build-tags "cleveldb,rocksdb,boltdb,badgerdb"
+	@go mod verify
+.PHONY: lint-all
 
 format:
 	find . -name '*.go' -type f -not -path "*.git*" -not -name '*.pb.go' -not -name '*pb_test.go' | xargs gofmt -w -s
@@ -111,24 +99,23 @@ format:
 tools:
 	go get -v $(GOTOOLS)
 
-.PHONY: cleveldb rocksdb
-cleveldb:
-	@if [ ! -e $(CLEVELDB_DIR) ]; then         \
-		sh contrib/get_cleveldb.sh;        \
+build-cleveldb:
+	@if [ ! -e $(CLEVELDB_DIR) ]; then \
+		sh ./contrib/get_cleveldb.sh; \
 	fi
-	@if [ ! -e $(CLEVELDB_DIR)/libcleveldb.a ]; then   \
-		cd $(CLEVELDB_DIR);                        \
-		cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DLEVELDB_BUILD_TESTS=OFF -DLEVELDB_BUILD_BENCHMARKS=OFF; \
-		cmake --build build;                                      \
+	@if [ ! -e $(CLEVELDB_DIR)/libcleveldb.a ]; then \
+		cd $(CLEVELDB_DIR) && make; \
 	fi
+.PHONY: build-cleveldb
 
-rocksdb.build:
-	@if [ ! -e $(ROCKSDB_DIR) ]; then          \
-		sh ./contrib/get_rocksdb.sh;         \
+build-rocksdb:
+	@if [ ! -e $(ROCKSDB_DIR) ]; then \
+		sh ./contrib/get_rocksdb.sh; \
 	fi
-	@if [ ! -e $(ROCKSDB_DIR)/librocksdb.a ]; then    \
+	@if [ ! -e $(ROCKSDB_DIR)/librocksdb.a ]; then \
 		cd $(ROCKSDB_DIR) && make -j4 static_lib; \
 	fi
+.PHONY: build-rocksdb
 
 # generates certificates for TLS testing in remotedb
 gen_certs: clean_certs
@@ -151,5 +138,25 @@ clean_certs:
 	## Note the $@ here is substituted for the %.pb.go
 	protoc $(INCLUDE) $< --gogo_out=Mgoogle/protobuf/timestamp.proto=github.com/golang/protobuf/ptypes/timestamp,plugins=grpc:.
 
+protoc_remotedb: remotedb/proto/defs.pb.go
 
-protoc_remotedb: remotedb/proto/defs.pb.go	
+build-local-docker:
+	## If you met the compile error, it might be the shortage of memory on docker with your machine
+	## Please check your Docker Desktop and its settings of resources
+	## for mac: https://docs.docker.com/desktop/mac/#resources
+	## for windows: https://docs.docker.com/desktop/windows/#resources
+	@docker build --rm --progress plain --tag="$(DOCKER_IMAGE)" -f ./tools/Dockerfile .
+.PHONY: build-local-docker
+
+bash-local-docker:
+	## If you want to `golangci-lint` in Docker,
+	## should install `golangci-lint` after Docker container start with bash and
+	## should be the same version of lint.yml.
+	## See: .github/lint.yml
+	##
+	## example: golangci-lint
+	##
+	## curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.1
+	## golangci-lint run --build-tags "cleveldb,rocksdb,boltdb,badgerdb"
+	@docker run --rm -it -e CGO_LDFLAGS="-lrocksdb" -v $(CURDIR):/workspace --workdir /workspace $(DOCKER_IMAGE) bash
+.PHONY: bash-local-docker

--- a/remotedb/remotedb_test.go
+++ b/remotedb/remotedb_test.go
@@ -1,5 +1,3 @@
-// +build remotedb
-
 package remotedb_test
 
 import (

--- a/rocksdb.go
+++ b/rocksdb.go
@@ -1,3 +1,4 @@
+//go:build rocksdb
 // +build rocksdb
 
 package db

--- a/rocksdb_batch.go
+++ b/rocksdb_batch.go
@@ -1,3 +1,4 @@
+//go:build rocksdb
 // +build rocksdb
 
 package db

--- a/rocksdb_iterator.go
+++ b/rocksdb_iterator.go
@@ -1,3 +1,4 @@
+//go:build rocksdb
 // +build rocksdb
 
 package db

--- a/rocksdb_test.go
+++ b/rocksdb_test.go
@@ -1,3 +1,4 @@
+//go:build rocksdb
 // +build rocksdb
 
 package db

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,5 +1,5 @@
 # This file defines the container image used to build and test tm-db in CI.
-# The CI workflows use the latest tag of tendermintdev/docker-tm-db-testing
+# The CI workflows use the latest tag of line/tm-db-testing
 # built from these settings.
 #
 # The jobs defined in the Build & Push workflow will build and update the image
@@ -7,7 +7,7 @@
 # updates here, merge the changes here first and let the image get updated (or
 # push a new version manually) before PRs that depend on them.
 
-FROM golang:1.17-bullseye AS build
+FROM golang:1.16-bullseye AS build
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
@@ -16,29 +16,27 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     make tar wget
 
 FROM build AS install
-ARG LEVELDB=1.20
-ARG ROCKSDB=6.24.2
+
+COPY ./contrib/ ./contrib
 
 # Install cleveldb
 RUN \
-  wget -q https://github.com/google/leveldb/archive/v${LEVELDB}.tar.gz \
-  && tar xvf v${LEVELDB}.tar.gz \
-  && cd leveldb-${LEVELDB} \
+  ./contrib/get_cleveldb.sh \
+  && cd leveldb \
   && make \
   && cp -a out-static/lib* out-shared/lib* /usr/local/lib \
   && cd include \
   && cp -a leveldb /usr/local/include \
-  && ldconfig \
-  && cd ../.. \
-  && rm -rf v${LEVELDB}.tar.gz leveldb-${LEVELDB}
+  && ldconfig
 
 # Install Rocksdb
 RUN \
-  wget -q https://github.com/facebook/rocksdb/archive/v${ROCKSDB}.tar.gz \
-  && tar -zxf v${ROCKSDB}.tar.gz \
-  && cd rocksdb-${ROCKSDB} \
+  ./contrib/get_rocksdb.sh \
+  && cd rocksdb \
   && DEBUG_LEVEL=0 make -j4 shared_lib \
   && make install-shared \
-  && ldconfig \
-  && cd .. \
-  && rm -rf v${ROCKSDB}.tar.gz rocksdb-${ROCKSDB}
+  && ldconfig
+
+RUN rm -rf ./leveldb-*.tar.gz leveldb
+RUN rm -rf ./rocksdb-*.tar.gz rocksdb
+RUN rm -rf ./contrib

--- a/util_test.go
+++ b/util_test.go
@@ -114,7 +114,7 @@ func TestPrefixIteratorMatches1N(t *testing.T) {
 			// Bad!
 			checkNext(t, itr, false)
 
-			//Once invalid...
+			// Once invalid...
 			checkInvalid(t, itr)
 		})
 	}
@@ -150,4 +150,9 @@ func TestConcat(t *testing.T) {
 	require.Equal(t, prefix, concat(prefix, nil))
 	require.Equal(t, key, concat(nil, key))
 	require.Equal(t, []byte{}, concat(nil, nil))
+}
+
+// TestMakePath is made for lint
+func TestMakePath(t *testing.T) {
+	require.Nil(t, makePath(""))
 }


### PR DESCRIPTION
Currently, `rocksdb-v6.24.2` is compiled for the Docker image registered in Docker Hub at the last commit. `rocksdb-v6.24.2` is known as an incompatible version, and if you don't fix `line/gorocksdb` and `tm-db/rocksdb` correctly, you will get an error in `Test/Lint`. 

Test error:
```
/go/pkg/mod/github.com/line/gorocksdb@v0.0.0-20210406043732-d4bea34b6d55/filter_policy.go:49:72: cannot use _Ctype_int(bitsPerKey) (type _Ctype_int) as type _Ctype_double in argument to _Cfunc_rocksdb_filterpolicy_create_bloom
/go/pkg/mod/github.com/line/gorocksdb@v0.0.0-20210406043732-d4bea34b6d55/filter_policy.go:55:77: cannot use _Ctype_int(bitsPerKey) (type _Ctype_int) as type _Ctype_double in argument to _Cfunc_rocksdb_filterpolicy_create_bloom_full
FAIL    github.com/line/tm-db/v2 [build failed]
FAIL    github.com/line/tm-db/v2/remotedb [build failed]
FAIL    github.com/line/tm-db/v2/remotedb/grpcdb [build failed]
```
Lint error:
```
rdb.go:8:8: could not import C (cgo preprocessing failed) (typecheck)
import "C"
```

This PR will once re-create a Docker image using the previous version of `rocksdb-v6.20.3` for future development.
- https://github.com/line/tm-db/pull/36/files#diff-d646ebc0b928f98f9fd35691e83dabbdadf87617293d1f03b2f806eb4cecd99eL23
<img width="750" alt="screenshot 2022-04-13 14 43 29" src="https://user-images.githubusercontent.com/1164270/163108393-f170cd25-53e9-4162-8ce9-32cfaccde967.png">

As a side note, `tm-db` cannot `Test/Lint` without a Docker image. Also, the Docker image of `tm-db` will not be updated unless this PR is merged (pushed).

See: https://github.com/line/tm-db/blob/main/.github/workflows/docker.yml#L4-L7
```
# This workflow does not push a new image until it is merged, so tests that
# depend on changes in this image will not pass until this workflow succeeds.
# For that reason, changes here should be done in a separate PR in advance of
# work that depends on them.
```

# Changes:
* Temporary ignore the tag of `rocksdb` on `golangci-lint/go test`
* Use the same version of `leveldb/rocksdb` on `makefile/Dokcerfile`
* Use the same version of golang on `makefile/Dokcerfile`
* Use the same docker image  on `makefile/Dokcerfile`
* Remove CODEOWNERS
* Fix typo
* Add the build directories of `leveldb/rocksdb` into gitignore
