### PR TITLE
Enable the build tag of `rocksdb`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: line/tm-db-testing
+      env:
+        CGO_LDFLAGS: -lrocksdb
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -31,8 +33,8 @@ jobs:
       - name: test & coverage report creation
         run: |
           go test ./... -mod=readonly -timeout 8m -race -coverprofile=coverage.txt -covermode=atomic \
-          -tags=cleveldb,boltdb,badgerdb -v # ignore rocksdb
+          -tags=cleveldb,rocksdb,boltdb,badgerdb -v
       - uses: codecov/codecov-action@v2.0.3
         with:
           file: ./coverage.txt
-          fail_ci_if_error: true  
+          fail_ci_if_error: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: line/tm-db-testing
+      env:
+        CGO_LDFLAGS: -lrocksdb
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -26,5 +28,5 @@ jobs:
           # specified without patch version: we always use the latest patch
           # version.
           version: v1.42.1
-          args: --timeout 10m --build-tags "cleveldb,boltdb,badgerdb" # ignore rocksdb
+          args: --timeout 10m --build-tags "cleveldb,rocksdb,boltdb,badgerdb"
           github-token: ${{ secrets.github_token }}


### PR DESCRIPTION
This PR(https://github.com/line/tm-db/pull/41) ignored the build tag of `rocksdb` in `lint/test` once. Now, we can enable that again.