### PR TITLE
Add benchmark each databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ Go 1.16+
 
 - **MemDB [stable]:** An in-memory database using [Google's B-tree package](https://github.com/google/btree). Has very high performance both for reads, writes, and range scans, but is not durable and will lose all data on process exit. Does not support transactions. Suitable for e.g. caches, working sets, and tests. Used for [IAVL](https://github.com/tendermint/iavl) working sets when the pruning strategy allows it.
 
-- **[LevelDB](https://github.com/google/leveldb) [experimental]:** A [Go wrapper](https://github.com/jmhodges/levigo) around [LevelDB](https://github.com/google/leveldb). Uses LSM-trees for on-disk storage, which have good performance for write-heavy workloads, particularly on spinning disks, but requires periodic compaction to maintain decent read performance and reclaim disk space. Does not support transactions.
+- **[LevelDB](https://github.com/google/leveldb) [rc]:** A [Go wrapper](https://github.com/jmhodges/levigo) around [LevelDB](https://github.com/google/leveldb). Uses LSM-trees for on-disk storage, which have good performance for write-heavy workloads, particularly on spinning disks, but requires periodic compaction to maintain decent read performance and reclaim disk space. Does not support transactions.
+
+- **[RocksDB](https://github.com/line/gorocksdb) [rc]:** A [Go wrapper](https://github.com/line/gorocksdb) around [RocksDB](https://rocksdb.org). Similarly to LevelDB (above) it uses LSM-trees for on-disk storage, but is optimized for fast storage media such as SSDs and memory. Supports atomic transactions, but not full ACID transactions.
+
+### Experimental Database Backends
 
 - **[BoltDB](https://github.com/etcd-io/bbolt) [experimental]:** A [fork](https://github.com/etcd-io/bbolt) of [BoltDB](https://github.com/boltdb/bolt). Uses B+trees for on-disk storage, which have good performance for read-heavy workloads and range scans. Supports serializable ACID transactions.
-
-- **[RocksDB](https://github.com/line/gorocksdb) [experimental]:** A [Go wrapper](https://github.com/line/gorocksdb) around [RocksDB](https://rocksdb.org). Similarly to LevelDB (above) it uses LSM-trees for on-disk storage, but is optimized for fast storage media such as SSDs and memory. Supports atomic transactions, but not full ACID transactions.
 
 - **[BadgerDB](https://github.com/dgraph-io/badger) [experimental]:** A key-value database written as a pure-Go alternative to e.g. LevelDB and RocksDB, with LSM-tree storage. Makes use of multiple goroutines for performance, and includes advanced features such as serializable ACID transactions, write batches, compression, and more.
 
@@ -29,3 +31,28 @@ Go 1.16+
 ## Tests
 
 To test common databases, run `make test`. If all databases are available on the local machine, use `make test-all` to test them all.
+
+```bash
+make test
+make test-all
+make test-all-docker
+```
+
+## Benchmark
+
+```bash
+make bench
+make bench-all
+make bench-all-docker
+```
+
+### Comparison databases
+
+```bash
+# Read/Write
+make bench-rw-all
+# Scan 1M
+make bench-scan1m-all
+# Scan 10M
+make bench-scan10m-all
+```

--- a/backend_test.go
+++ b/backend_test.go
@@ -26,6 +26,17 @@ func init() {
 	}, false)
 }
 
+func closeDBWithCleanupDBDir(db DB, dir, name string) {
+	defer cleanupDBDir(dir, name)
+	// MEMO:
+	// `RocksDB.Close()` happen `abort` with calling 2 times more in the same process
+	// `CGO.abort` cannot recover safety
+	err := db.Close()
+	if err != nil {
+		panic(err)
+	}
+}
+
 func cleanupDBDir(dir, name string) {
 	err := os.RemoveAll(filepath.Join(dir, name) + ".db")
 	if err != nil {

--- a/backend_test.go
+++ b/backend_test.go
@@ -154,16 +154,6 @@ func TestBackendsGetSetDelete(t *testing.T) {
 	}
 }
 
-func TestGoLevelDBBackend(t *testing.T) {
-	name := fmt.Sprintf("test_%x", randStr(12))
-	db, err := NewDB(name, GoLevelDBBackend, "")
-	require.NoError(t, err)
-	defer cleanupDBDir("", name)
-
-	_, ok := db.(*GoLevelDB)
-	assert.True(t, ok)
-}
-
 func TestDBIterator(t *testing.T) {
 	for dbType := range backends {
 		t.Run(string(dbType), func(t *testing.T) {

--- a/badger_db.go
+++ b/badger_db.go
@@ -23,7 +23,7 @@ func badgerDBCreator(dbName, dir string) (DB, error) {
 func NewBadgerDB(dbName, dir string) (*BadgerDB, error) {
 	// Since Badger doesn't support database names, we join both to obtain
 	// the final directory to use for the database.
-	path := filepath.Join(dir, dbName)
+	path := filepath.Join(dir, dbName+".db")
 
 	if err := makePath(path); err != nil {
 		return nil, err

--- a/badger_db_test.go
+++ b/badger_db_test.go
@@ -1,3 +1,6 @@
+//go:build badgerdb
+// +build badgerdb
+
 package db
 
 import (
@@ -9,51 +12,55 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGoLevelDBNewDB(t *testing.T) {
+func TestBadgerDBNewDB(t *testing.T) {
 	name := fmt.Sprintf("test_%x", randStr(12))
 	dir := os.TempDir()
-	db, err := NewDB(name, GoLevelDBBackend, dir)
+	db, err := NewDB(name, BadgerDBBackend, dir)
 	defer closeDBWithCleanupDBDir(db, dir, name)
 	require.NoError(t, err)
 
-	_, ok := db.(*GoLevelDB)
+	_, ok := db.(*BadgerDB)
 	assert.True(t, ok)
 }
 
-func TestGoLevelDBStats(t *testing.T) {
+func TestBadgerDBStats(t *testing.T) {
 	name := fmt.Sprintf("test_%x", randStr(12))
 	dir := os.TempDir()
-	db, err := NewDB(name, GoLevelDBBackend, dir)
+	db, err := NewDB(name, BadgerDBBackend, dir)
 	defer closeDBWithCleanupDBDir(db, dir, name)
 	require.NoError(t, err)
 
-	assert.NotEmpty(t, db.Stats())
+	assert.Nil(t, db.Stats()) // Not implement
 }
 
-func BenchmarkGoLevelDBRangeScans1M(b *testing.B) {
+// Cannot work well since the data setup time is long (10min over)
+// See the read/write performance: BenchmarkBadgerDBRandomReadsWrites
+func TempBenchmarkBadgerDBRangeScans1M(b *testing.B) {
 	name := fmt.Sprintf("test_%x", randStr(12))
 	dir := os.TempDir()
-	db, err := NewDB(name, GoLevelDBBackend, dir)
+	db, err := NewDB(name, BadgerDBBackend, dir)
 	defer closeDBWithCleanupDBDir(db, dir, name)
 	require.NoError(b, err)
 
 	benchmarkRangeScans(b, db, int64(1e6))
 }
 
-func BenchmarkGoLevelDBRangeScans10M(b *testing.B) {
+// Cannot work well since the data setup time is long (10min over)
+// See the read/write performance: BenchmarkBadgerDBRandomReadsWrites
+func TempBenchmarkBadgerDBRangeScans10M(b *testing.B) {
 	name := fmt.Sprintf("test_%x", randStr(12))
 	dir := os.TempDir()
-	db, err := NewDB(name, GoLevelDBBackend, dir)
+	db, err := NewDB(name, BadgerDBBackend, dir)
 	defer closeDBWithCleanupDBDir(db, dir, name)
 	require.NoError(b, err)
 
 	benchmarkRangeScans(b, db, int64(10e6))
 }
 
-func BenchmarkGoLevelDBRandomReadsWrites(b *testing.B) {
+func BenchmarkBadgerDBRandomReadsWrites(b *testing.B) {
 	name := fmt.Sprintf("test_%x", randStr(12))
 	dir := os.TempDir()
-	db, err := NewGoLevelDB(name, dir)
+	db, err := NewBadgerDB(name, dir)
 	defer closeDBWithCleanupDBDir(db, dir, name)
 	require.NoError(b, err)
 

--- a/makefile
+++ b/makefile
@@ -71,12 +71,27 @@ bench-badgerdb:
 
 bench-all: build-cleveldb build-rocksdb
 	@CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
-	go test -bench=. $(PACKAGES) -tags cleveldb,rocksdb,boltdb,badgerdb
+	go test -bench=. $(PACKAGES) -tags cleveldb,rocksdb,boltdb,badgerdb -timeout 20m
 
 bench-all-docker:
 	@docker run --rm -e CGO_LDFLAGS="-lrocksdb" -v $(CURDIR):/workspace --workdir /workspace $(DOCKER_IMAGE) \
-	go test -bench=. $(PACKAGES) -tags cleveldb,rocksdb,boltdb,badgerdb
+	go test -bench=. $(PACKAGES) -tags cleveldb,rocksdb,boltdb,badgerdb -timeout 20m
 .PHONY: bench-all-docker
+
+bench-rw-all: build-cleveldb build-rocksdb
+	@CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
+	go test -bench=DBRandomReadsWrites github.com/line/tm-db/v2 -benchtime 10s -count 5 -timeout 20m \
+	-tags cleveldb,rocksdb,boltdb,badgerdb
+
+bench-scan1m-all: build-cleveldb build-rocksdb
+	@CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
+	go test -bench=DBRangeScans1M github.com/line/tm-db/v2 -benchtime 1s -count 1 \
+	-tags cleveldb,rocksdb,boltdb,badgerdb
+
+bench-scan10m-all: build-cleveldb build-rocksdb
+	@CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
+	go test -bench=DBRangeScans10M github.com/line/tm-db/v2 -benchtime 1s -count 1 \
+	-tags cleveldb,rocksdb,boltdb,badgerdb -timeout 20m
 
 lint:
 	@echo "--> Running linter"

--- a/rdb_test.go
+++ b/rdb_test.go
@@ -16,7 +16,7 @@ func TestRDBNewDB(t *testing.T) {
 	name := fmt.Sprintf("test_%x", randStr(12))
 	dir := os.TempDir()
 	db, err := NewDB(name, RDBBackend, dir)
-	defer cleanupDBDir(dir, name)
+	defer closeDBWithCleanupDBDir(db, dir, name)
 	require.NoError(t, err)
 
 	_, ok := db.(*RDB)
@@ -27,7 +27,7 @@ func TestRDBStats(t *testing.T) {
 	name := fmt.Sprintf("test_%x", randStr(12))
 	dir := os.TempDir()
 	db, err := NewDB(name, RDBBackend, dir)
-	defer cleanupDBDir(dir, name)
+	defer closeDBWithCleanupDBDir(db, dir, name)
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, db.Stats())
@@ -37,7 +37,7 @@ func BenchmarkRDBRangeScans1M(b *testing.B) {
 	name := fmt.Sprintf("test_%x", randStr(12))
 	dir := os.TempDir()
 	db, err := NewDB(name, RDBBackend, dir)
-	defer cleanupDBDir(dir, name)
+	defer closeDBWithCleanupDBDir(db, dir, name)
 	require.NoError(b, err)
 
 	benchmarkRangeScans(b, db, int64(1e6))
@@ -47,7 +47,7 @@ func BenchmarkRDBRangeScans10M(b *testing.B) {
 	name := fmt.Sprintf("test_%x", randStr(12))
 	dir := os.TempDir()
 	db, err := NewDB(name, RDBBackend, dir)
-	defer cleanupDBDir(dir, name)
+	defer closeDBWithCleanupDBDir(db, dir, name)
 	require.NoError(b, err)
 
 	benchmarkRangeScans(b, db, int64(10e6))
@@ -56,8 +56,8 @@ func BenchmarkRDBRangeScans10M(b *testing.B) {
 func BenchmarkRDBRandomReadsWrites(b *testing.B) {
 	name := fmt.Sprintf("test_%x", randStr(12))
 	dir := os.TempDir()
-	db, err := NewDB(name, RDBBackend, dir)
-	defer cleanupDBDir(dir, name)
+	db, err := NewRDB(name, dir)
+	defer closeDBWithCleanupDBDir(db, dir, name)
 	require.NoError(b, err)
 
 	benchmarkRandomReadsWrites(b, db)

--- a/rocksdb.go
+++ b/rocksdb.go
@@ -149,12 +149,13 @@ func (db *RocksDB) DB() *gorocksdb.DB {
 	return db.db
 }
 
+// FIXME Unsafe db.db.Close() with multiple calling
 // Close implements DB.
 func (db *RocksDB) Close() error {
-	db.db.Close()
 	db.ro.Destroy()
 	db.wo.Destroy()
 	db.woSync.Destroy()
+	db.db.Close()
 	return nil
 }
 

--- a/rocksdb_test.go
+++ b/rocksdb_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRocksDBBackend(t *testing.T) {
+func TestRocksDBNewDB(t *testing.T) {
 	name := fmt.Sprintf("test_%x", randStr(12))
 	dir := os.TempDir()
 	db, err := NewDB(name, RocksDBBackend, dir)
+	defer cleanupDBDir(dir, name) // Cannot use `closeDBWithCleanupDBDir`
 	require.NoError(t, err)
-	defer cleanupDBDir(dir, name)
 
 	_, ok := db.(*RocksDB)
 	assert.True(t, ok)
@@ -27,10 +27,38 @@ func TestRocksDBStats(t *testing.T) {
 	name := fmt.Sprintf("test_%x", randStr(12))
 	dir := os.TempDir()
 	db, err := NewDB(name, RocksDBBackend, dir)
+	defer cleanupDBDir(dir, name) // Cannot use `closeDBWithCleanupDBDir`
 	require.NoError(t, err)
-	defer cleanupDBDir(dir, name)
 
 	assert.NotEmpty(t, db.Stats())
 }
 
-// TODO: Add tests for rocksdb
+func BenchmarkRocksDBRangeScans1M(b *testing.B) {
+	name := fmt.Sprintf("test_%x", randStr(12))
+	dir := os.TempDir()
+	db, err := NewDB(name, RocksDBBackend, dir)
+	defer cleanupDBDir(dir, name) // Cannot use `closeDBWithCleanupDBDir`
+	require.NoError(b, err)
+
+	benchmarkRangeScans(b, db, int64(1e6))
+}
+
+func BenchmarkRocksDBRangeScans10M(b *testing.B) {
+	name := fmt.Sprintf("test_%x", randStr(12))
+	dir := os.TempDir()
+	db, err := NewDB(name, RocksDBBackend, dir)
+	defer cleanupDBDir(dir, name) // Cannot use `closeDBWithCleanupDBDir`
+	require.NoError(b, err)
+
+	benchmarkRangeScans(b, db, int64(10e6))
+}
+
+func BenchmarkRocksDBRandomReadsWrites(b *testing.B) {
+	name := fmt.Sprintf("test_%x", randStr(12))
+	dir := os.TempDir()
+	db, err := NewRocksDB(name, dir)
+	defer cleanupDBDir(dir, name) // Cannot use `closeDBWithCleanupDBDir`
+	require.NoError(b, err)
+
+	benchmarkRandomReadsWrites(b, db)
+}


### PR DESCRIPTION
Prepared benchmark tests for comparison and benchmarked. 

# Summary
- **`CLevelDB`** is the fastest
- **`RDB`** and **`RocksDB`** are almost the same
- `BadgerDB` is half of `GoLevelDB`
- `BoldDB` is the slowest
- _MemDB_ is for reference value

```
(MemDB) >> CLevelDB > RDB/RocksDB > GoLevelDB >> BadgerDB >>>> BoldDB
```

# Detail
Here is the benchmark result:

* 1st time:
```
$ make bench-rw-all
make[1]: Nothing to be done for `default'.
goos: darwin
goarch: amd64
pkg: github.com/line/tm-db/v2
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkBadgerDBRandomReadsWrites-12             426609             25751 ns/op
BenchmarkBadgerDBRandomReadsWrites-12             463836             33014 ns/op
BenchmarkBadgerDBRandomReadsWrites-12             416019             25843 ns/op
BenchmarkBadgerDBRandomReadsWrites-12             475720             24244 ns/op
BenchmarkBadgerDBRandomReadsWrites-12             478244             23885 ns/op
BenchmarkBoltDBRandomReadsWrites-12                  229          51060296 ns/op
BenchmarkBoltDBRandomReadsWrites-12                  224          51146392 ns/op
BenchmarkBoltDBRandomReadsWrites-12                  223          53136768 ns/op
BenchmarkBoltDBRandomReadsWrites-12                  228          51044285 ns/op
BenchmarkBoltDBRandomReadsWrites-12                  228          51634704 ns/op
BenchmarkCLevelDBRandomReadsWrites-12            1493834              8640 ns/op
BenchmarkCLevelDBRandomReadsWrites-12            1484905              8696 ns/op
BenchmarkCLevelDBRandomReadsWrites-12            1461402              8773 ns/op
BenchmarkCLevelDBRandomReadsWrites-12            1396650              8607 ns/op
BenchmarkCLevelDBRandomReadsWrites-12            1481521              8734 ns/op
BenchmarkGoLevelDBRandomReadsWrites-12            800504             12584 ns/op
BenchmarkGoLevelDBRandomReadsWrites-12            991490             12476 ns/op
BenchmarkGoLevelDBRandomReadsWrites-12           1047990             12109 ns/op
BenchmarkGoLevelDBRandomReadsWrites-12            812607             13113 ns/op
BenchmarkGoLevelDBRandomReadsWrites-12            908769             15855 ns/op
BenchmarkMemDBRandomReadsWrites-12               3127154              4947 ns/op
BenchmarkMemDBRandomReadsWrites-12               3029884              4300 ns/op
BenchmarkMemDBRandomReadsWrites-12               3226206              4292 ns/op
BenchmarkMemDBRandomReadsWrites-12               3246740              4431 ns/op
BenchmarkMemDBRandomReadsWrites-12               2590572              4512 ns/op
BenchmarkRDBRandomReadsWrites-12                 1325365              9072 ns/op
BenchmarkRDBRandomReadsWrites-12                 1303948              9177 ns/op
BenchmarkRDBRandomReadsWrites-12                 1000000             10486 ns/op
BenchmarkRDBRandomReadsWrites-12                 1229834             10073 ns/op
BenchmarkRDBRandomReadsWrites-12                 1013259             11086 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1364755              9060 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1338634              9172 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1350940              9318 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1304858              9226 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1314782              9195 ns/op
PASS
ok      github.com/line/tm-db/v2        734.848s

```

* 2nd time:
```
$ make bench-rw-all
make[1]: Nothing to be done for `default'.
goos: darwin
goarch: amd64
pkg: github.com/line/tm-db/v2
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkBadgerDBRandomReadsWrites-12             406041             38262 ns/op
BenchmarkBadgerDBRandomReadsWrites-12             355297             36821 ns/op
BenchmarkBadgerDBRandomReadsWrites-12             431964             29792 ns/op
BenchmarkBadgerDBRandomReadsWrites-12             462464             27360 ns/op
BenchmarkBadgerDBRandomReadsWrites-12             334826             41952 ns/op
BenchmarkBoltDBRandomReadsWrites-12                  224          52057568 ns/op
BenchmarkBoltDBRandomReadsWrites-12                  218          52554646 ns/op
BenchmarkBoltDBRandomReadsWrites-12                  254          51367564 ns/op
BenchmarkBoltDBRandomReadsWrites-12                  225          51924644 ns/op
BenchmarkBoltDBRandomReadsWrites-12                  229          51647700 ns/op
BenchmarkCLevelDBRandomReadsWrites-12            1209210             12140 ns/op
BenchmarkCLevelDBRandomReadsWrites-12             697240             17535 ns/op
BenchmarkCLevelDBRandomReadsWrites-12             817388             14303 ns/op
BenchmarkCLevelDBRandomReadsWrites-12             884217             12038 ns/op
BenchmarkCLevelDBRandomReadsWrites-12             859362             14757 ns/op
BenchmarkGoLevelDBRandomReadsWrites-12            781196             12950 ns/op
BenchmarkGoLevelDBRandomReadsWrites-12            810252             12439 ns/op
BenchmarkGoLevelDBRandomReadsWrites-12            803967             13308 ns/op
BenchmarkGoLevelDBRandomReadsWrites-12            790243             15512 ns/op
BenchmarkGoLevelDBRandomReadsWrites-12            903302             23964 ns/op
BenchmarkMemDBRandomReadsWrites-12               2829098              5067 ns/op
BenchmarkMemDBRandomReadsWrites-12               3168566              4505 ns/op
BenchmarkMemDBRandomReadsWrites-12               2876498              4381 ns/op
BenchmarkMemDBRandomReadsWrites-12               2938623              4763 ns/op
BenchmarkMemDBRandomReadsWrites-12               2928001              4657 ns/op
BenchmarkRDBRandomReadsWrites-12                 1000000             10996 ns/op
BenchmarkRDBRandomReadsWrites-12                 1000000             10404 ns/op
BenchmarkRDBRandomReadsWrites-12                 1000000             10299 ns/op
BenchmarkRDBRandomReadsWrites-12                 1359388             10097 ns/op
BenchmarkRDBRandomReadsWrites-12                 1000000             10363 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1000000             10675 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1332363              9740 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1239312             10932 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1123947              9264 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1000000             10802 ns/op
PASS
ok      github.com/line/tm-db/v2        715.620s
```

* 3rd time without boltdb/badgerdb:
```diff
$ git diff
diff --git a/makefile b/makefile
index 994e929..f63d1d8 100644
--- a/makefile
+++ b/makefile
@@ -81,7 +81,7 @@ bench-all-docker:
 bench-rw-all: build-cleveldb build-rocksdb
        @CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
        go test -bench=DBRandomReadsWrites github.com/line/tm-db/v2 -benchtime 10s -count 5 -timeout 20m \
-       -tags cleveldb,rocksdb,boltdb,badgerdb
+       -tags cleveldb,rocksdb
 
 bench-scan1m-all: build-cleveldb build-rocksdb
        @CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
```
```
$ make bench-rw-all
make[1]: Nothing to be done for `default'.
goos: darwin
goarch: amd64
pkg: github.com/line/tm-db/v2
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkCLevelDBRandomReadsWrites-12            1258400             10505 ns/op
BenchmarkCLevelDBRandomReadsWrites-12            1476763             10765 ns/op
BenchmarkCLevelDBRandomReadsWrites-12            1483126              8759 ns/op
BenchmarkCLevelDBRandomReadsWrites-12            1481695              8713 ns/op
BenchmarkCLevelDBRandomReadsWrites-12            1493053              8712 ns/op
BenchmarkGoLevelDBRandomReadsWrites-12            961932             11965 ns/op
BenchmarkGoLevelDBRandomReadsWrites-12           1040487             16632 ns/op
BenchmarkGoLevelDBRandomReadsWrites-12            692804             17521 ns/op
BenchmarkGoLevelDBRandomReadsWrites-12            954393             17420 ns/op
BenchmarkGoLevelDBRandomReadsWrites-12            782653             16938 ns/op
BenchmarkMemDBRandomReadsWrites-12               3075397              5151 ns/op
BenchmarkMemDBRandomReadsWrites-12               1804982              6455 ns/op
BenchmarkMemDBRandomReadsWrites-12               3220651              4771 ns/op
BenchmarkMemDBRandomReadsWrites-12               2875860              4416 ns/op
BenchmarkMemDBRandomReadsWrites-12               3002506              5135 ns/op
BenchmarkRDBRandomReadsWrites-12                 1247577              9226 ns/op
BenchmarkRDBRandomReadsWrites-12                 1388053              8843 ns/op
BenchmarkRDBRandomReadsWrites-12                 1000000             10266 ns/op
BenchmarkRDBRandomReadsWrites-12                 1000000             15567 ns/op
BenchmarkRDBRandomReadsWrites-12                  792700             17013 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1000000             10731 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1425877              9796 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1000000             16742 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1000000             10382 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1225044              9377 ns/op
PASS
ok      github.com/line/tm-db/v2        505.832s
```

* 4th time without memdb/gorocksdb:
```
$ git diff
diff --git a/goleveldb_test.go b/goleveldb_test.go
index 17d3576..dd09dd4 100644
--- a/goleveldb_test.go
+++ b/goleveldb_test.go
@@ -50,7 +50,7 @@ func BenchmarkGoLevelDBRangeScans10M(b *testing.B) {
        benchmarkRangeScans(b, db, int64(10e6))
 }
 
-func BenchmarkGoLevelDBRandomReadsWrites(b *testing.B) {
+func TempBenchmarkGoLevelDBRandomReadsWrites(b *testing.B) {
        name := fmt.Sprintf("test_%x", randStr(12))
        dir := os.TempDir()
        db, err := NewGoLevelDB(name, dir)
diff --git a/makefile b/makefile
index 994e929..f63d1d8 100644
--- a/makefile
+++ b/makefile
@@ -81,7 +81,7 @@ bench-all-docker:
 bench-rw-all: build-cleveldb build-rocksdb
        @CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
        go test -bench=DBRandomReadsWrites github.com/line/tm-db/v2 -benchtime 10s -count 5 -timeout 20m \
-       -tags cleveldb,rocksdb,boltdb,badgerdb
+       -tags cleveldb,rocksdb
 
 bench-scan1m-all: build-cleveldb build-rocksdb
        @CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
diff --git a/memdb_test.go b/memdb_test.go
index 4e67e81..c51db8e 100644
--- a/memdb_test.go
+++ b/memdb_test.go
@@ -18,7 +18,7 @@ func BenchmarkMemDBRangeScans10M(b *testing.B) {
        benchmarkRangeScans(b, db, int64(10e6))
 }
 
-func BenchmarkMemDBRandomReadsWrites(b *testing.B) {
+func TempBenchmarkMemDBRandomReadsWrites(b *testing.B) {
        db := NewMemDB()
        defer db.Close()
```
```
$ make bench-rw-all
make[1]: Nothing to be done for `default'.
goos: darwin
goarch: amd64
pkg: github.com/line/tm-db/v2
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkCLevelDBRandomReadsWrites-12            1443411              8752 ns/op
BenchmarkCLevelDBRandomReadsWrites-12            1471560              8859 ns/op
BenchmarkCLevelDBRandomReadsWrites-12            1484053              8984 ns/op
BenchmarkCLevelDBRandomReadsWrites-12            1445342              8810 ns/op
BenchmarkCLevelDBRandomReadsWrites-12            1474443              8877 ns/op
BenchmarkRDBRandomReadsWrites-12                 1362651              8845 ns/op
BenchmarkRDBRandomReadsWrites-12                 1376300              8840 ns/op
BenchmarkRDBRandomReadsWrites-12                 1371985              8773 ns/op
BenchmarkRDBRandomReadsWrites-12                 1384676              8915 ns/op
BenchmarkRDBRandomReadsWrites-12                 1379982              8982 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1383940              8922 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1373077              9005 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1372785              9190 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1340666              8952 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1371046              8969 ns/op
PASS
ok      github.com/line/tm-db/v2        339.755s
```