### PR TITLE
bugfix push/load on buildx

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -82,10 +82,10 @@ jobs:
           context: .
           file: ./tools/Dockerfile
           push: ${{ github.event_name == 'push' }}
+          load: ${{ github.event_name != 'push' }}
           tags: ${{ steps.prep.outputs.tag }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-          load: true
 
       - name: Move cache
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,17 +1,9 @@
 name: Lint with registered Docker Image
 on:
+  pull_request:
   push:
     branches:
       - main
-    paths:
-      - "!contrib/*"
-      - "!tools/*"
-      - "!go.mod"
-  pull_request:
-    paths:
-      - "!contrib/*"
-      - "!tools/*"
-      - "!go.mod"
   workflow_call:
     inputs:
       CACHE_DIR:
@@ -25,9 +17,25 @@ on:
         type: string
 
 jobs:
-  lint-with-registerd-docker-image:
+  changes:
     runs-on: ubuntu-latest
     if: ${{ inputs.CACHE_FILE == '' }}
+    outputs:
+      paths: ${{ steps.filter.outputs.paths }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            paths:
+              - "contrib/*"
+              - "tools/*"
+              - "go.mod"
+
+  lint-with-registerd-docker-image:
+    needs: changes
+    runs-on: ubuntu-latest
+    if: ${{ inputs.CACHE_FILE == '' && needs.changes.outputs.paths != 'true' }}
     container:
       image: line/tm-db-testing
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,9 @@
 name: Test with registered Docker Image
 on:
+  pull_request:
   push:
     branches:
       - main
-    paths:
-      - "!contrib/*"
-      - "!tools/*"
-      - "!go.mod"
-  pull_request:
-    paths:
-      - "!contrib/*"
-      - "!tools/*"
-      - "!go.mod"
   workflow_call:
     inputs:
       CACHE_DIR:
@@ -33,9 +25,25 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main'"
 
-  test-with-registerd-docker-image:
+  changes:
     runs-on: ubuntu-latest
     if: ${{ inputs.CACHE_FILE == '' }}
+    outputs:
+      paths: ${{ steps.filter.outputs.paths }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            paths:
+              - "contrib/*"
+              - "tools/*"
+              - "go.mod"
+
+  test-with-registerd-docker-image:
+    needs: changes
+    runs-on: ubuntu-latest
+    if: ${{ inputs.CACHE_FILE == '' && needs.changes.outputs.paths != 'true' }}
     container:
       image: line/tm-db-testing
       credentials:

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -42,7 +42,7 @@ RUN rm -rf ./rocksdb-*.tar.gz rocksdb
 RUN rm -rf ./contrib
 
 # Install golangci for CI
-RUN go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
+RUN go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
 
 # Download dependency modules for CI
 WORKDIR /workspace


### PR DESCRIPTION
The previous pull-request has a bug. https://github.com/line/tm-db/pull/43

See the bug: https://github.com/line/tm-db/runs/6367072708?check_suite_focus=true

### push and load may not be set together at the moment in docker.yml
```
error: push and load may not be set together at the moment
Error: buildx failed with: error: push and load may not be set together at the moment
```

### don't work paths in lint.yml/test.yml

See the next PR checks: https://github.com/line/tm-db/pull/48/checks
See the github actions paths documents: 
* https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths
```
If you define a path with the ! character, you must also define at least one path without the ! character. 
If you only want to exclude paths, use paths-ignore instead.
```