### PR TITLE
Upgrade to golang-1.18

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.16
+          go-version: 1.17
       - uses: actions/checkout@v3
       - name: lint
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - uses: actions/checkout@v3
       - name: lint
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       - uses: actions/checkout@v3
       - name: test & coverage report creation
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
       - uses: actions/checkout@v3
       - name: test & coverage report creation
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,15 +16,15 @@ linters:
     # - godox
     - gofmt
     - goimports
-    - golint
+    # - golint
     - gosec
     - gosimple
-    - govet
+    # - govet
     - ineffassign
     # - interfacer
     - lll
     - misspell
-    - maligned
+    # - maligned
     - nakedret
     - prealloc
     # - scopelint
@@ -40,6 +40,7 @@ linters:
     # - wsl
     # - gocognit
     - nolintlint
+    - revive
 
 issues:
   exclude-rules:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Please don't make Pull Requests from `main`.
 
 ## Dependencies
 
-We use [Go 1.17 Modules](https://github.com/golang/go/wiki/Modules) to manage
+We use [Go 1.18 Modules](https://github.com/golang/go/wiki/Modules) to manage
 dependency versions.
 
 The `main` branch of every LFB repository should just build with `go get`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Please don't make Pull Requests from `main`.
 
 ## Dependencies
 
-We use [Go 1.16 Modules](https://github.com/golang/go/wiki/Modules) to manage
+We use [Go 1.17 Modules](https://github.com/golang/go/wiki/Modules) to manage
 dependency versions.
 
 The `main` branch of every LFB repository should just build with `go get`,

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Common database interface for various database backends. This is forked for appl
 
 ### Minimum Go Version
 
-Go 1.16+
+Go 1.17+
 
 ## Supported Database Backends
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Common database interface for various database backends. This is forked for appl
 
 ### Minimum Go Version
 
-Go 1.17+
+Go 1.18+
 
 ## Supported Database Backends
 

--- a/badger_db.go
+++ b/badger_db.go
@@ -9,7 +9,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 )
 
 func init() { registerDBCreator(BadgerDBBackend, badgerDBCreator, true) }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/line/tm-db/v2
 
-go 1.16
+go 1.17
 
 require (
 	github.com/dgraph-io/badger/v2 v2.2007.2
@@ -12,6 +12,25 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca
 	go.etcd.io/bbolt v1.3.6
 	google.golang.org/grpc v1.42.0
+)
+
+require (
+	github.com/DataDog/zstd v1.4.1 // indirect
+	github.com/cespare/xxhash v1.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de // indirect
+	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
+	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f // indirect
+	golang.org/x/text v0.3.3 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
 
 // FIXME: gorocksdb bindings for OptimisticTransactionDB are not merged upstream, so we use a fork

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/line/tm-db/v2
 
-go 1.17
+go 1.18
 
 require (
 	github.com/dgraph-io/badger/v2 v2.2007.2

--- a/makefile
+++ b/makefile
@@ -102,14 +102,14 @@ lint:
 lint-all: build-cleveldb build-rocksdb
 	@echo "--> Running linter"
 	@CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
-	golangci-lint run --build-tags "cleveldb,rocksdb,boltdb,badgerdb"
+	golangci-lint run --build-tags "cleveldb,rocksdb,boltdb,badgerdb" --timeout 5m
 	@go mod verify
 .PHONY: lint-all
 
 lint-all-docker:
 	@echo "--> Running go lint"
 	@docker run --rm -e CGO_LDFLAGS="-lrocksdb" -v $(CURDIR):/workspace --workdir /workspace $(DOCKER_IMAGE) \
-	golangci-lint run --build-tags "cleveldb,rocksdb,boltdb,badgerdb"
+	golangci-lint run --build-tags "cleveldb,rocksdb,boltdb,badgerdb" --timeout 5m
 .PHONY: test-all-docker
 
 format:

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -7,7 +7,7 @@
 # updates here, merge the changes here first and let the image get updated (or
 # push a new version manually) before PRs that depend on them.
 
-FROM golang:1.17-bullseye AS build
+FROM golang:1.18-bullseye AS build
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -7,7 +7,7 @@
 # updates here, merge the changes here first and let the image get updated (or
 # push a new version manually) before PRs that depend on them.
 
-FROM golang:1.16-bullseye AS build
+FROM golang:1.17-bullseye AS build
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -42,7 +42,7 @@ RUN rm -rf ./rocksdb-*.tar.gz rocksdb
 RUN rm -rf ./contrib
 
 # Install golangci for CI
-RUN go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
+RUN go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
 
 # Download dependency modules for CI
 WORKDIR /workspace


### PR DESCRIPTION
* Fix `golangci-lint` warnings before upgrading `Golang`
* Upgrade to **Golang-1.17**
* Upgrade to **Golang-1.18**
* Upgrade `golangci-lint` for a warning

MEMO:
Left the warnings of `golangci-lint` by go-1.18 since it will be supported by the newer `golangci-lint`

See the warnings:
* https://github.com/line/tm-db/runs/6520727715?check_suite_focus=true#step:5:13
* https://github.com/line/tm-db/runs/6520727715?check_suite_focus=true#step:5:15

```
level=warning msg="[linters context] bodyclose is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649."
level=warning msg="[linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649."
```
