### PR TITLE
Add benchmark parallel test on each database

### DIFF
--- a/badger_db_test.go
+++ b/badger_db_test.go
@@ -31,6 +31,13 @@ func BenchmarkBadgerDBRandomReadsWrites(b *testing.B) {
 	benchmarkRandomReadsWrites(b, db)
 }
 
+func BenchmarkBadgerDBParallelRandomReadsWrites(b *testing.B) {
+	db, dir, name := newDB(b, BadgerDBBackend)
+	defer closeDBWithCleanupDBDir(db, dir, name)
+
+	benchmarkParallelRandomReadsWrites(b, db)
+}
+
 // Cannot work well since the data setup time is long (10min over)
 // See the read/write performance: BenchmarkBadgerDBRandomReadsWrites
 func TempBenchmarkBadgerDBRangeScans1M(b *testing.B) {

--- a/boltdb_test.go
+++ b/boltdb_test.go
@@ -48,3 +48,10 @@ func BenchmarkBoltDBRandomReadsWrites(b *testing.B) {
 
 	benchmarkRandomReadsWrites(b, db)
 }
+
+func BenchmarkBoltDBParallelRandomReadsWrites(b *testing.B) {
+	db, dir, name := newDB(b, BoltDBBackend)
+	defer closeDBWithCleanupDBDir(db, dir, name)
+
+	benchmarkParallelRandomReadsWrites(b, db)
+}

--- a/cleveldb_test.go
+++ b/cleveldb_test.go
@@ -116,3 +116,10 @@ func BenchmarkCLevelDBRandomReadsWrites(b *testing.B) {
 
 	benchmarkRandomReadsWrites(b, db)
 }
+
+func BenchmarkCLevelDBParallelRandomReadsWrites(b *testing.B) {
+	db, dir, name := newDB(b, CLevelDBBackend)
+	defer closeDBWithCleanupDBDir(db, dir, name)
+
+	benchmarkParallelRandomReadsWrites(b, db)
+}

--- a/goleveldb_test.go
+++ b/goleveldb_test.go
@@ -27,6 +27,13 @@ func BenchmarkGoLevelDBRandomReadsWrites(b *testing.B) {
 	benchmarkRandomReadsWrites(b, db)
 }
 
+func BenchmarkGoLevelDBParallelRandomReadsWrites(b *testing.B) {
+	db, dir, name := newDB(b, GoLevelDBBackend)
+	defer closeDBWithCleanupDBDir(db, dir, name)
+
+	benchmarkParallelRandomReadsWrites(b, db)
+}
+
 func TestGoLevelDBNewDB(t *testing.T) {
 	db, dir, name := newDB(t, GoLevelDBBackend)
 	defer closeDBWithCleanupDBDir(db, dir, name)

--- a/makefile
+++ b/makefile
@@ -53,45 +53,50 @@ test-all-docker:
 .PHONY: test-all-docker
 
 bench:
-	@go test -bench=. $(PACKAGES)
+	@go test -bench=. -run=^$ $(PACKAGES)
 
 bench-cleveldb: build-cleveldb
 	@CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
-	go test -bench=. $(PACKAGES) -tags cleveldb
+	go test -bench=. -run=^$ $(PACKAGES) -tags cleveldb
 
 bench-rocksdb: build-rocksdb
 	@CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
-	go test -bench=. $(PACKAGES) -tags rocksdb
+	go test -bench=. -run=^$ $(PACKAGES) -tags rocksdb
 
 bench-boltdb:
-	@go test -bench=. $(PACKAGES) -tags boltdb
+	@go test -bench=. -run=^$ $(PACKAGES) -tags boltdb
 
 bench-badgerdb:
-	@go test -bench=. $(PACKAGES) -tags badgerdb
+	@go test -bench=. -run=^$ $(PACKAGES) -tags badgerdb
 
 bench-all: build-cleveldb build-rocksdb
 	@CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
-	go test -bench=. $(PACKAGES) -tags cleveldb,rocksdb,boltdb,badgerdb -timeout 20m
+	go test -bench=. -run=^$ $(PACKAGES) -timeout 20m -tags cleveldb,rocksdb,boltdb,badgerdb
 
 bench-all-docker:
 	@docker run --rm -e CGO_LDFLAGS="-lrocksdb" -v $(CURDIR):/workspace --workdir /workspace $(DOCKER_IMAGE) \
-	go test -bench=. $(PACKAGES) -tags cleveldb,rocksdb,boltdb,badgerdb -timeout 20m
+	go test -bench=. -run=^$ $(PACKAGES) -timeout 20m -tags cleveldb,rocksdb,boltdb,badgerdb
 .PHONY: bench-all-docker
 
 bench-rw-all: build-cleveldb build-rocksdb
 	@CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
-	go test -bench=DBRandomReadsWrites github.com/line/tm-db/v2 -benchtime 10s -count 5 -timeout 20m \
+	go test -bench=DBRandomReadsWrites -run=^$ github.com/line/tm-db/v2 -benchtime 10s -count 5 -timeout 20m \
+	-tags cleveldb,rocksdb,boltdb,badgerdb
+
+bench-parallel-rw-all: build-cleveldb build-rocksdb
+	@CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
+	go test -bench=DBParallelRandomReadsWrites -run=^$ github.com/line/tm-db/v2 -benchtime 10s -count 5 -timeout 20m \
 	-tags cleveldb,rocksdb,boltdb,badgerdb
 
 bench-scan1m-all: build-cleveldb build-rocksdb
 	@CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
-	go test -bench=DBRangeScans1M github.com/line/tm-db/v2 -benchtime 1s -count 1 \
+	go test -bench=DBRangeScans1M -run=^$ github.com/line/tm-db/v2 -benchtime 1s -count 1 \
 	-tags cleveldb,rocksdb,boltdb,badgerdb
 
 bench-scan10m-all: build-cleveldb build-rocksdb
 	@CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
-	go test -bench=DBRangeScans10M github.com/line/tm-db/v2 -benchtime 1s -count 1 \
-	-tags cleveldb,rocksdb,boltdb,badgerdb -timeout 20m
+	go test -bench=DBRangeScans10M -run=^$ github.com/line/tm-db/v2 -benchtime 1s -count 1  -timeout 20m \
+	-tags cleveldb,rocksdb,boltdb,badgerdb
 
 lint:
 	@echo "--> Running linter"

--- a/memdb_test.go
+++ b/memdb_test.go
@@ -24,3 +24,10 @@ func BenchmarkMemDBRandomReadsWrites(b *testing.B) {
 
 	benchmarkRandomReadsWrites(b, db)
 }
+
+func BenchmarkMemDBParallelRandomReadsWrites(b *testing.B) {
+	db := NewMemDB()
+	defer db.Close()
+
+	benchmarkParallelRandomReadsWrites(b, db)
+}

--- a/rdb_test.go
+++ b/rdb_test.go
@@ -44,3 +44,10 @@ func BenchmarkRDBRandomReadsWrites(b *testing.B) {
 
 	benchmarkRandomReadsWrites(b, db)
 }
+
+func BenchmarkRDBParallelRandomReadsWrites(b *testing.B) {
+	db, dir, name := newDB(b, RDBBackend)
+	defer closeDBWithCleanupDBDir(db, dir, name)
+
+	benchmarkParallelRandomReadsWrites(b, db)
+}

--- a/rocksdb_test.go
+++ b/rocksdb_test.go
@@ -44,3 +44,10 @@ func BenchmarkRocksDBRandomReadsWrites(b *testing.B) {
 
 	benchmarkRandomReadsWrites(b, db)
 }
+
+func BenchmarkRocksDBParallelRandomReadsWrites(b *testing.B) {
+	db, dir, name := newDB(b, RocksDBBackend)
+	defer cleanupDBDir(dir, name) // Cannot use `closeDBWithCleanupDBDir`
+
+	benchmarkParallelRandomReadsWrites(b, db)
+}


### PR DESCRIPTION
* Add benchmark concurrency test on each databases
* Improve `benchmarkRandomReadsWrites`
* Add `-run=^$` on the `makefile` task

Relates: https://github.com/line/tm-db/pull/48

# Summary
RDB gets the high average in the three types of tests. If RDB improves scanning, it makes a win in the backends.
* Sequencial random reads/writes: (MemDB) >>> CLevelDB > RocksDB/RDB > GoLevelDB >> BadgerDB >>> BoltDB
* Parallel random reads/writes: (MemDB) > RDB > RocksDB > GoLevelDB > CLevelDB > BadgerDB >>> BoltDB
* Scan 1M, 10M: (MemDB) > GoLevelDB >> RocksDB > RDB > CLevelDB >>> BadgerDB >>>>>>>>> (BoltDB)

## In parallel tests
* RDB is the fastest, almost the same as MemDB
* GoLevelDB is almost the same as RocksDB
* CLevelDB is slower than GoLevelDB
* BadgerDB has increased the performance
* BoltDB is still the slowest

## In scan tests
* GoLevelDB is the fastest, almost the same as MemDB
* But GoLevelDB is slower than RocksDB with scanning 10M
* RocksDB/RDB is the faster than CLevelDB
* BadgerDB is not almost working
* BoltDB cannot test

# Detail

## Sequencial random reads/writes: -benchtime 10s -count 5
```
$ make bench-rw-all
make[1]: Nothing to be done for `default'.
goos: darwin
goarch: amd64
pkg: github.com/line/tm-db/v2
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkBadgerDBRandomReadsWrites-12             433153             27896 ns/op
BenchmarkBadgerDBRandomReadsWrites-12             430416             25516 ns/op
BenchmarkBadgerDBRandomReadsWrites-12             431889             28445 ns/op
BenchmarkBadgerDBRandomReadsWrites-12             357687             28299 ns/op
BenchmarkBadgerDBRandomReadsWrites-12             432754             28291 ns/op
BenchmarkBoltDBRandomReadsWrites-12                  236          51745308 ns/op
BenchmarkBoltDBRandomReadsWrites-12                  236          50565452 ns/op
BenchmarkBoltDBRandomReadsWrites-12                  236          50846334 ns/op
BenchmarkBoltDBRandomReadsWrites-12                  236          51079507 ns/op
BenchmarkBoltDBRandomReadsWrites-12                  231          50648964 ns/op
BenchmarkCLevelDBRandomReadsWrites-12            1383342              8731 ns/op
BenchmarkCLevelDBRandomReadsWrites-12            1498341              8563 ns/op
BenchmarkCLevelDBRandomReadsWrites-12            1355560              9625 ns/op
BenchmarkCLevelDBRandomReadsWrites-12            1240560              8990 ns/op
BenchmarkCLevelDBRandomReadsWrites-12            1280602             10516 ns/op
BenchmarkGoLevelDBRandomReadsWrites-12           1000000             12918 ns/op
BenchmarkGoLevelDBRandomReadsWrites-12           1000000             13224 ns/op
BenchmarkGoLevelDBRandomReadsWrites-12           1000000             13454 ns/op
BenchmarkGoLevelDBRandomReadsWrites-12           1000000             14060 ns/op
BenchmarkGoLevelDBRandomReadsWrites-12           1000000             13074 ns/op
BenchmarkMemDBRandomReadsWrites-12               2947477              4645 ns/op
BenchmarkMemDBRandomReadsWrites-12               3371552              4097 ns/op
BenchmarkMemDBRandomReadsWrites-12               3529815              4431 ns/op
BenchmarkMemDBRandomReadsWrites-12               3181850              4554 ns/op
BenchmarkMemDBRandomReadsWrites-12               3214174              4261 ns/op
BenchmarkRDBRandomReadsWrites-12                 1387717             10019 ns/op
BenchmarkRDBRandomReadsWrites-12                 1359913              8928 ns/op
BenchmarkRDBRandomReadsWrites-12                 1354479              9456 ns/op
BenchmarkRDBRandomReadsWrites-12                 1000000             10478 ns/op
BenchmarkRDBRandomReadsWrites-12                 1325730             10373 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1400572             10055 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1346559              9530 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1312984              8933 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1312676              9523 ns/op
BenchmarkRocksDBRandomReadsWrites-12             1000000             10526 ns/op
PASS
ok      github.com/line/tm-db/v2        658.220s
```

## Parallel random reads/writes: -benchtime 10s -count 5
```
$ make bench-parallel-rw-all
make[1]: Nothing to be done for `default'.
goos: darwin
goarch: amd64
pkg: github.com/line/tm-db/v2
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkBadgerDBParallelRandomReadsWrites-12            1213801             10009 ns/op
BenchmarkBadgerDBParallelRandomReadsWrites-12            1230820             10598 ns/op
BenchmarkBadgerDBParallelRandomReadsWrites-12            1236434              9807 ns/op
BenchmarkBadgerDBParallelRandomReadsWrites-12            1265180              9802 ns/op
BenchmarkBadgerDBParallelRandomReadsWrites-12            1256522              9846 ns/op
BenchmarkBoltDBParallelRandomReadsWrites-12                  237          51792582 ns/op
BenchmarkBoltDBParallelRandomReadsWrites-12                  228          50548908 ns/op
BenchmarkBoltDBParallelRandomReadsWrites-12                  234          51105656 ns/op
BenchmarkBoltDBParallelRandomReadsWrites-12                  235          50182536 ns/op
BenchmarkBoltDBParallelRandomReadsWrites-12                  235          50340789 ns/op
BenchmarkCLevelDBParallelRandomReadsWrites-12            1505988              9165 ns/op
BenchmarkCLevelDBParallelRandomReadsWrites-12            1488946              7346 ns/op
BenchmarkCLevelDBParallelRandomReadsWrites-12            1680372              7643 ns/op
BenchmarkCLevelDBParallelRandomReadsWrites-12            1656693              7685 ns/op
BenchmarkCLevelDBParallelRandomReadsWrites-12            1612558              7590 ns/op
BenchmarkGoLevelDBParallelRandomReadsWrites-12           1929177              6607 ns/op
BenchmarkGoLevelDBParallelRandomReadsWrites-12           2028115              6630 ns/op
BenchmarkGoLevelDBParallelRandomReadsWrites-12           1977219              6590 ns/op
BenchmarkGoLevelDBParallelRandomReadsWrites-12           1963966              6719 ns/op
BenchmarkGoLevelDBParallelRandomReadsWrites-12           1900972              6681 ns/op
BenchmarkMemDBParallelRandomReadsWrites-12               2961358              4716 ns/op
BenchmarkMemDBParallelRandomReadsWrites-12               3050127              5020 ns/op
BenchmarkMemDBParallelRandomReadsWrites-12               2936424              4897 ns/op
BenchmarkMemDBParallelRandomReadsWrites-12               2925367              4874 ns/op
BenchmarkMemDBParallelRandomReadsWrites-12               2914748              4965 ns/op
BenchmarkRDBParallelRandomReadsWrites-12                 3813910              4031 ns/op
BenchmarkRDBParallelRandomReadsWrites-12                 3050524              4734 ns/op
BenchmarkRDBParallelRandomReadsWrites-12                 2618752              4762 ns/op
BenchmarkRDBParallelRandomReadsWrites-12                 2738322              4880 ns/op
BenchmarkRDBParallelRandomReadsWrites-12                 2637764              4860 ns/op
BenchmarkRocksDBParallelRandomReadsWrites-12             2068816              6060 ns/op
BenchmarkRocksDBParallelRandomReadsWrites-12             2007366              6200 ns/op
BenchmarkRocksDBParallelRandomReadsWrites-12             2065000              6185 ns/op
BenchmarkRocksDBParallelRandomReadsWrites-12             1987688              6226 ns/op
BenchmarkRocksDBParallelRandomReadsWrites-12             2025757              6195 ns/op
PASS
ok      github.com/line/tm-db/v2        655.275s
```

## Scan 1M: -benchtime 1s -count 1
```
$ make bench-scan1m-all
make[1]: Nothing to be done for `default'.
goos: darwin
goarch: amd64
pkg: github.com/line/tm-db/v2
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkBadgerDBRangeScans1M-12               1        1076762335 ns/op
BenchmarkCLevelDBRangeScans1M-12             241           4636135 ns/op
BenchmarkGoLevelDBRangeScans1M-12            753           1544308 ns/op
BenchmarkMemDBRangeScans1M-12                874           1392395 ns/op
BenchmarkRDBRangeScans1M-12                  312           3585211 ns/op
BenchmarkRocksDBRangeScans1M-12              334           3737942 ns/op
PASS
ok      github.com/line/tm-db/v2        111.074s
```

## Scan 10M: -benchtime 1s -count 1
```
$ make bench-scan10m-all
make[1]: Nothing to be done for `default'.
goos: darwin
goarch: amd64
pkg: github.com/line/tm-db/v2
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkCLevelDBRangeScans10M-12            140           7367583 ns/op
BenchmarkGoLevelDBRangeScans10M-12           397           2933491 ns/op
BenchmarkMemDBRangeScans10M-12               852           1543244 ns/op
BenchmarkRDBRangeScans10M-12                 223           4809545 ns/op
BenchmarkRocksDBRangeScans10M-12             408           3613556 ns/op
PASS
ok      github.com/line/tm-db/v2        900.922s
```
